### PR TITLE
Change target work for at-tib and nujum examples

### DIFF
--- a/data/ratings/works/languages.ts
+++ b/data/ratings/works/languages.ts
@@ -1,9 +1,9 @@
 export default {
   examples: [
-    { query: 'at-tib', ratings: ['vyqkhbsd'] },
-    { query: 'Aṭ-ṭib', ratings: ['vyqkhbsd'] },
-    { query: 'nuğūm', ratings: ['nut59kt9'] },
-    { query: 'nujum', ratings: ['nut59kt9'] },
+    { query: 'at-tib', ratings: ['qmm9mauk'] },
+    { query: 'Aṭ-ṭib', ratings: ['qmm9mauk'] },
+    { query: 'nuğūm', ratings: ['jtbenqbq'] },
+    { query: 'nujum', ratings: ['jtbenqbq'] },
     { query: 'arbeiten', ratings: ['xn7yyrqf'] },
     { query: 'travaillons', ratings: ['jb823ud6'] },
     { query: 'conosceva', ratings: ['va2vy7wb'] },


### PR DESCRIPTION
The target works for some of our language tests have been deleted, so can't be matched by any of our queries. 

The tests themselves are still appropriate, but the specific examples need to be changed for rank eval to pass.

| Query | Old target | New target |
|-|-|-|
| nujum |https://wellcomecollection.org/works/nut59kt9| https://wellcomecollection.org/works/jtbenqbq |
| at-tib |https://wellcomecollection.org/works/vyqkhbsd| https://wellcomecollection.org/works/qmm9mauk |

The new target works have been approved by collections info.