### PR TITLE
Feat/elastic management

### DIFF
--- a/.github/workflows/ccr.yml
+++ b/.github/workflows/ccr.yml
@@ -1,0 +1,13 @@
+name: ccr-manage-everyday-at-8-am
+on:
+  schedule:
+    - cron: '0 8 * * *'
+jobs:
+  cron:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Manage CCR
+        run: |
+          curl --request POST \
+          --url 'https://rank.wellcomecollection.org/api/ccr' \
+          --header 'Authorization: Bearer ${{ secrets.CCR_MANAGE_API_KEY }}'

--- a/pages/api/ccr.ts
+++ b/pages/api/ccr.ts
@@ -1,5 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { env } from 'node:process'
 import { rankClient } from '../../services/elasticsearch'
 import { getSearchTemplates } from '../../services/search-templates'
 
@@ -17,17 +16,17 @@ export default async (
   const auth = process.env.CCR_MANAGE_API_KEY
   const authHeader = req.headers.authorization
 
-  // if (false || !auth || !authHeader || auth !== process.env.CCR_MANAGE_API_KEY) {
-  //   res.statusCode = 401
-  //   res.setHeader('Content-Type', 'application/json')
-  //   res.end(
-  //     JSON.stringify({
-  //       statusCode: 401,
-  //       message: 'unauthorised',
-  //     })
-  //   )
-  //   return
-  // }
+  if (!auth || !authHeader || auth !== process.env.CCR_MANAGE_API_KEY) {
+    res.statusCode = 401
+    res.setHeader('Content-Type', 'application/json')
+    res.end(
+      JSON.stringify({
+        statusCode: 401,
+        message: 'unauthorised',
+      })
+    )
+    return
+  }
 
   const searchTemplates = await getSearchTemplates('prod')
   const { body: allIndices } = await rankClient.indices.get({ index: '_all' })

--- a/pages/api/ccr.ts
+++ b/pages/api/ccr.ts
@@ -1,0 +1,102 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { env } from 'node:process'
+import { rankClient } from '../../services/elasticsearch'
+import { getSearchTemplates } from '../../services/search-templates'
+
+function getNamespace(indexName: string) {
+  return indexName.split('-')[0]
+}
+type State = {
+  index: string
+  state: 'delete' | 'exists' | 'follow'
+}
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const auth = process.env.CCR_MANAGE_API_KEY
+  const authHeader = req.headers.authorization
+
+  // if (false || !auth || !authHeader || auth !== process.env.CCR_MANAGE_API_KEY) {
+  //   res.statusCode = 401
+  //   res.setHeader('Content-Type', 'application/json')
+  //   res.end(
+  //     JSON.stringify({
+  //       statusCode: 401,
+  //       message: 'unauthorised',
+  //     })
+  //   )
+  //   return
+  // }
+
+  const searchTemplates = await getSearchTemplates('prod')
+  const { body: allIndices } = await rankClient.indices.get({ index: '_all' })
+
+  const state: State[] = (
+    await Promise.all(
+      searchTemplates.templates.map(async (template) => {
+        const namespace = getNamespace(template.index)
+        const ccrIndexName = `ccr--${template.index}`
+        // we're only working with works for now, but should extend to images
+        if (namespace === 'works') {
+          const { body: indexExists } = await rankClient.indices.exists({
+            index: ccrIndexName,
+          })
+
+          if (indexExists) {
+            console.info(`${ccrIndexName} exists, moving on`)
+            return [
+              {
+                index: ccrIndexName,
+                state: 'exists',
+              } as State,
+            ]
+          }
+
+          // delete previous indices
+          const indices = Object.keys(allIndices).filter((index) =>
+            index.startsWith(`ccr--${namespace}`)
+          )
+          if (indices.length > 0) {
+            console.info(`deleting ${indices}`)
+            await rankClient.indices
+              .delete({
+                index: indices,
+              })
+              .catch((err) => ({ body: err }))
+          }
+
+          await rankClient.ccr.follow({
+            index: ccrIndexName,
+            body: {
+              remote_cluster: 'catalogue',
+              leader_index: template.index,
+              settings: {
+                'index.number_of_replicas': 0,
+              },
+            },
+          })
+
+          return [
+            ...indices.map(
+              (index) =>
+                ({
+                  index,
+                  state: 'delete',
+                } as State)
+            ),
+            { index: ccrIndexName, state: 'follow' } as State,
+          ]
+        }
+      })
+    )
+  )
+
+    .flat()
+    // We can sometimes have `null` as we don't run this on all templates yet
+    .filter(Boolean)
+
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ state }))
+}

--- a/services/elasticsearch.ts
+++ b/services/elasticsearch.ts
@@ -5,6 +5,9 @@ const {
   ES_USER,
   ES_PASSWORD,
   ES_CLOUD_ID,
+  ES_RANK_USER,
+  ES_RANK_PASSWORD,
+  ES_RANK_CLOUD_ID,
   ES_RATINGS_USER,
   ES_RATINGS_PASSWORD,
   ES_RATINGS_CLOUD_ID,
@@ -58,6 +61,16 @@ const client = new Client({
   },
 })
 
+const rankClient = new Client({
+  cloud: {
+    id: ES_RANK_CLOUD_ID,
+  },
+  auth: {
+    username: ES_RANK_USER,
+    password: ES_RANK_PASSWORD,
+  },
+})
+
 const ratingClient = new Client({
   cloud: {
     id: ES_RATINGS_CLOUD_ID,
@@ -68,4 +81,4 @@ const ratingClient = new Client({
   },
 })
 
-export { client, ratingClient }
+export { client, rankClient, ratingClient }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,12 +8,12 @@ resource "ec_deployment" "rank_catalogue" {
   name                   = "rank_catalogue"
   region                 = "eu-west-1"
   version                = data.ec_stack.latest.version
-  deployment_template_id = "aws-cross-cluster-search-v2"
+  deployment_template_id = "aws-io-optimized-v2"
 
   elasticsearch {
     topology {
       id         = "hot_content"
-      size       = "1g"
+      size       = "4g"
       zone_count = 1
     }
 


### PR DESCRIPTION
A spike to see how we can manage [CCR](https://www.elastic.co/guide/en/cloud/current/ec-enable-ccs.html) in the rank test cluster

* Runs a cron job each day at 08:00
* Checks to see if we have the latest prod follower index
* If so, move on
* If not, delete all previous CCR indexes (prefixed with `ccr--`)
* Create a new follow index `ccr--{indexName}`

And you're away for testing. All testing indexes will remain if you're using them.

Next up I am going to write a script to create the `.env.local` from SSM.