### PR TITLE
use new pass properties in search

### DIFF
--- a/data/ratings/pass.ts
+++ b/data/ratings/pass.ts
@@ -15,7 +15,7 @@ const eq1: PassFn = (rankDetail: RankDetail) => {
 
 const eq0: PassFn = (rankDetail: RankDetail) => {
   return {
-    score: rankDetail.metric_score === 1 ? 0 : 1,
+    score: rankDetail.metric_score,
     pass: rankDetail.metric_score === 0,
   }
 }

--- a/data/ratings/works.ts
+++ b/data/ratings/works.ts
@@ -67,6 +67,9 @@ const ratings: Record<string, Rating> = {
     },
   },
   negative: {
+    label: 'False positives',
+    description:
+      "Due to fuzzy matching on alternative spellings, we need to ensure we aren't too fuzzy.",
     pass: eq0,
     searchTemplateAugmentation: filterExamples,
     examples: [

--- a/pages/api/eval.ts
+++ b/pages/api/eval.ts
@@ -33,7 +33,7 @@ function formatExamples(examples: Example[], template: Template) {
 
 export function rankEvalRequests(
   template: Template
-): Promise<RankEvalResponse>[] {
+): Promise<RankEvalResponsWithMeta>[] {
   const queryType = indexToQueryType(template.index)
   const ratings = { works: workRatings, images: imageRatings }[queryType]
   const requests = Object.entries(

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,9 +1,14 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Template, getSearchTemplates } from '../../services/search-templates'
-import { rankClient } from '../../services/elasticsearch'
+import {
+  rankClient,
+  RankEvalResponsWithMeta,
+  SearchResponse,
+} from '../../services/elasticsearch'
 import { rankEvalRequests } from './eval'
+import { Endpoint } from '../search'
 
-async function getCurrentQuery(endpoint: string): Promise<Template> {
+async function getCurrentQuery(endpoint: Endpoint): Promise<Template> {
   const searchTemplates = await getSearchTemplates('prod')
   const template = searchTemplates.templates.find((template) =>
     template.index.startsWith(`ccr--${endpoint}`)
@@ -11,7 +16,7 @@ async function getCurrentQuery(endpoint: string): Promise<Template> {
   return template
 }
 
-async function getTestQuery(endpoint: string): Promise<Template> {
+async function getTestQuery(endpoint: Endpoint): Promise<Template> {
   const currentTemplate = await getCurrentQuery(endpoint)
   const query = await import(`../../data/queries/${endpoint}`).then(
     (q) => q.default
@@ -24,42 +29,68 @@ async function getTestQuery(endpoint: string): Promise<Template> {
   }
 }
 
+export type ApiResponse = SearchResponse & {
+  rankEval: RankEvalResponsWithMeta[]
+}
+
+export type ApiRequest = {
+  query?: string
+  useTestQuery?: 'true' | 'false'
+  endpoint?: Endpoint
+}
+
+type Q = NextApiRequest['query']
+const decoder = (q: Q) => ({
+  query: q.query ? q.query.toString() : undefined,
+  endpoint:
+    q.endpoint === 'works' || q.endpoint === 'images'
+      ? (q.endpoint as Endpoint)
+      : ('works' as Endpoint),
+  useTestQuery: q.useTestQuery === 'true' ?? false,
+})
+
 export default async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
-  const { query, useTestQuery, endpoint } = req.query
+  const { endpoint, query, useTestQuery } = decoder(req.query)
+
   const template = useTestQuery
-    ? await getTestQuery(endpoint as string)
-    : await getCurrentQuery(endpoint as string)
+    ? await getTestQuery(endpoint)
+    : await getCurrentQuery(endpoint)
 
   const rankEvalReqs = rankEvalRequests(template)
-  const searchReq = rankClient.searchTemplate({
-    index: template.index,
-    body: {
-      explain: true,
-      source: {
-        ...template.template.source,
-        track_total_hits: true,
-        highlight: {
-          pre_tags: ['<em class="bg-yellow-200">'],
-          post_tags: ['</em>'],
-          fields: { '*': { number_of_fragments: 0 } },
+  const searchReq = rankClient
+    .searchTemplate<SearchResponse>({
+      index: template.index,
+      body: {
+        explain: true,
+        source: {
+          ...template.template.source,
+          track_total_hits: true,
+          highlight: {
+            pre_tags: ['<em class="bg-yellow-200">'],
+            post_tags: ['</em>'],
+            fields: { '*': { number_of_fragments: 0 } },
+          },
         },
+        params: { query },
       },
-      params: { query },
-    },
-  })
+    })
+    .then((res) => res.body)
 
-  const requests = [searchReq, ...rankEvalReqs]
-  const [searchResp, ...rankEvalResps] = await Promise.all(requests as any[])
+  const requests: [
+    Promise<SearchResponse>,
+    Promise<RankEvalResponsWithMeta[]>
+  ] = [searchReq, Promise.all(rankEvalReqs)]
+
+  const [searchResp, ...[rankEvalResps]] = await Promise.all(requests)
+  const response: ApiResponse = {
+    ...searchResp,
+    rankEval: rankEvalResps,
+  }
 
   res.statusCode = 200
   res.setHeader('Content-Type', 'application/json')
-  res.end(
-    JSON.stringify({
-      ...searchResp.body,
-      rankEval: rankEvalResps,
-    })
-  )
+  res.end(JSON.stringify(response))
 }

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -124,7 +124,7 @@ const RankEval = ({ rankEval, search }) => {
       </button>
       {showRankEval && (
         <div className="flex flex-wrap">
-          {Object.entries(rankEval.details).map(([title, ranking], i) => (
+          {Object.entries(rankEval.details).map(([title], i) => (
             <Link
               href={{
                 pathname: '/search',

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -4,6 +4,7 @@ import { GetServerSideProps, NextPage } from 'next'
 import Link from 'next/link'
 import QueryForm from '../components/QueryForm'
 import absoluteUrl from 'next-absolute-url'
+import { Pass } from '../data/ratings/pass'
 
 type Props = {
   data?: any
@@ -46,21 +47,22 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
 }
 
 type RankEvalStatusProps = {
-  score: number
+  pass: Pass
 }
-const RankEvalStatus: FunctionComponent<RankEvalStatusProps> = ({ score }) => {
+const RankEvalStatus: FunctionComponent<RankEvalStatusProps> = ({ pass }) => {
   return (
     <div
       className={`w-5 h-5 mr-2 rounded-full bg-${
-        score === 1 ? 'green' : 'red'
+        pass.score === 1 ? 'green' : 'red'
       }-200`}
     >
-      <span className="sr-only">{score === 1 ? 'pass' : 'fail'}</span>
+      <span className="sr-only">{pass.score === 1 ? 'pass' : 'fail'}</span>
     </div>
   )
 }
 
-type HitProps = { hit: any; endpoint }
+type Endpoint = 'images' | 'works'
+type HitProps = { hit: any; endpoint: Endpoint }
 const Hit: FunctionComponent<HitProps> = ({ hit, endpoint }) => {
   const [showExplanation, setShowExplanation] = useState(false)
   const title =
@@ -117,15 +119,7 @@ const RankEval = ({ rankEval, search }) => {
         } rounded-full`}
         onClick={() => setShowRankEval(!showRankEval)}
       >
-        <RankEvalStatus
-          score={
-            Object.values(rankEval.details).every(
-              (ranking) => ((ranking as any).metric_score as any) === 1
-            )
-              ? 1
-              : 0
-          }
-        />
+        <RankEvalStatus pass={rankEval.pass} />
         {rankEval.queryId}
       </button>
       {showRankEval && (
@@ -145,7 +139,7 @@ const RankEval = ({ rankEval, search }) => {
               key={i}
             >
               <a className="flex flex-auto items-center mr-2 mb-2 p-2 bg-indigo-200 rounded-full">
-                <RankEvalStatus score={(ranking as any).metric_score} />
+                <RankEvalStatus pass={rankEval.passes[title]} />
                 <div>{title}</div>
               </a>
             </Link>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -167,7 +167,7 @@ const Search: NextPage<Props> = ({ data, search }) => {
       <ul>
         {data.hits.hits.map((hit) => (
           <li key={hit._id}>
-            <Hit hit={hit} endpoint={search.endpoint} />
+            <Hit hit={hit} endpoint={search.endpoint as Endpoint} />
           </li>
         ))}
       </ul>

--- a/services/elasticsearch.ts
+++ b/services/elasticsearch.ts
@@ -95,6 +95,27 @@ export type RankEvalResponsWithMeta = RankEvalResponse & {
   }
 }
 
+type Hit<DocType = Record<string, any>> = {
+  _id: string
+  _score: string
+  _source: DocType
+  _explanation: Record<string, unknown>
+  highlight: Record<string, string[]>
+  matched_queries: string[]
+}
+
+export type SearchResponse = {
+  took: number
+  hits: {
+    total: {
+      value: number
+      relation: 'eq' | 'gte'
+    }
+    max_score: number
+    hits: Hit[]
+  }
+}
+
 const rankClient = new Client({
   cloud: {
     id: ES_RANK_CLOUD_ID,

--- a/types.ts
+++ b/types.ts
@@ -11,6 +11,8 @@ export type Example = {
 }
 
 export type Rating = {
+  label?: string
+  description?: string
   pass: PassFn
   examples: Example[]
   metric: Metric


### PR DESCRIPTION
Makes sure we're reporting on pass / fail properly on the search page with the [new pass functionality](https://github.com/wellcomecollection/rank/pull/50)