### PR TITLE
Known failures

### DIFF
--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -13,9 +13,13 @@ test_cases = [
         search_terms="conosco",
         expected_ids=["nnh3nh47"],
         threshold_position=100,
+        known_failure=True,
     ),
     RecallTestCase(
-        search_terms="allons", expected_ids=["dqnapkdx"], threshold_position=100
+        search_terms="allons",
+        expected_ids=["dqnapkdx"],
+        threshold_position=100,
+        known_failure=True,
     ),
 ]
 

--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -21,7 +21,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_alternative_spellings(
     test_case: RecallTestCase, pipeline_client, images_search

--- a/cli/relevance_tests/images/test_precision.py
+++ b/cli/relevance_tests/images/test_precision.py
@@ -28,7 +28,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_precision(
     test_case: PrecisionTestCase, pipeline_client, images_search

--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -55,7 +55,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_recall(test_case: RecallTestCase, pipeline_client, images_search):
     response = pipeline_client.search(

--- a/cli/relevance_tests/models.py
+++ b/cli/relevance_tests/models.py
@@ -1,3 +1,4 @@
+import pytest
 from typing import List, Optional, ClassVar
 
 from pydantic import BaseModel, Field, model_validator
@@ -18,12 +19,28 @@ class TestCase(BaseModel):
         ),
         default=None,
     )
+    known_failure: bool = Field(
+        description=(
+            "If True, the test is expected to fail. If False, the test is "
+            "expected to pass."
+        ),
+        default=False,
+    )
 
     def __init__(self, **data):
         # if an id hasn't been set, use the search terms
         if "id" not in data:
             data["id"] = data["search_terms"]
         super().__init__(**data)
+
+    @property
+    def param(self):
+        """Return the test case as a pytest parameter"""
+        return pytest.param(
+            self,
+            id=self.id,
+            marks=pytest.mark.xfail if self.known_failure else None,
+        )
 
 
 class PrecisionTestCase(TestCase):

--- a/cli/relevance_tests/models.py
+++ b/cli/relevance_tests/models.py
@@ -39,7 +39,7 @@ class TestCase(BaseModel):
         return pytest.param(
             self,
             id=self.id,
-            marks=pytest.mark.xfail if self.known_failure else None,
+            marks=[pytest.mark.xfail] if self.known_failure else [],
         )
 
 

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -209,7 +209,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_alternative_spellings(
     test_case: RecallTestCase, pipeline_client, works_search

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -43,6 +43,7 @@ test_cases = [
             "k4k3jcvx",
             "yp67jjj5",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -56,6 +57,7 @@ test_cases = [
             "k4k3jcvx",
             "yp67jjj5",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -70,6 +72,7 @@ test_cases = [
             "pzbrggws",
             "zz45ck2v",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -84,6 +87,7 @@ test_cases = [
             "pzbrggws",
             "zz45ck2v",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -96,6 +100,7 @@ test_cases = [
             "y6qqmmeb",
             "m3hk4fkz",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -108,6 +113,7 @@ test_cases = [
             "y6qqmmeb",
             "m3hk4fkz",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -150,6 +156,7 @@ test_cases = [
             "mepptqy2",
             "a4sbkwqg",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -166,29 +173,34 @@ test_cases = [
             "mepptqy2",
             "a4sbkwqg",
         ],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="neuues",
         description="uu is folded to match w and vv in the title",
         expected_ids=["ker2t6s4", "m9rdjx58", "nu5dyw37"],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="nevves",
         description="uu is folded to match w and vv in the title",
         expected_ids=["ker2t6s4", "m9rdjx58", "nu5dyw37"],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="newes",
         description="w is folded to match uu and vv in the title",
         expected_ids=["ker2t6s4", "m9rdjx58", "nu5dyw37"],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="al-tibb",
         expected_ids=["t4jqq9ue"],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
@@ -199,11 +211,13 @@ test_cases = [
         threshold_position=1000,
         search_terms="nuğūm",
         expected_ids=["m94cyux7"],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="nujum",
         expected_ids=["m94cyux7"],
+        known_failure=True,
     ),
 ]
 

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -7,12 +7,14 @@ test_cases = [
         before_ids=["e8qxq5mv", "uuem7v9a"],
         after_ids=["n323a3a4", "jktm3e74", "frgjdu67"],
         description="Ensure that we return non-typos over typos e.g. query:stimming matches:stimming > swimming",
+        known_failure=True,
     ),
     OrderTestCase(
         search_terms="Crète",
         before_ids=["yyz378xr", "d6aezcvw", "z4yefjez"],
         after_ids=["gsehqy4k", "zq2yf7uz", "d2c3k3d3"],
         description="Term with diacritics is scored higher than the asciifolded equivalent, or versions with different diacritics",
+        known_failure=True,
     ),
     OrderTestCase(
         search_terms="horse furniture",
@@ -59,14 +61,17 @@ test_cases = [
     OrderTestCase(
         search_terms="aids poster",
         description="Matches ordered terms ahead of unordered terms",
+        id="aids poster - ordered terms ahead of unordered terms",
         before_ids=["t5sb3sab", "bry8xyza"],
         after_ids=["e8vnd4s7"],
     ),
     OrderTestCase(
         search_terms="aids poster",
         description="Matches both terms ahead of single term",
+        id="aids poster - both terms ahead of single term",
         before_ids=["t5sb3sab"],
         after_ids=["fyzv7d6h"],
+        known_failure=True,
     ),
     OrderTestCase(
         search_terms="x-ray",

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -85,7 +85,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_order(test_case: OrderTestCase, pipeline_client, works_search):
     response = pipeline_client.search(

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -56,6 +56,7 @@ test_cases = [
         search_terms="The Piggle",
         expected_ids=["q4drcxc6"],
         description="Example of a known title's prefix, but not the full thing",
+        known_failure=True,
     ),
     PrecisionTestCase(
         search_terms="Das neue Naturheilverfahren",
@@ -91,6 +92,7 @@ test_cases = [
         search_terms="Hunterian wa/hmm",
         expected_ids=["f3gpbk74"],
         description="archive reference number and a word from the title",
+        known_failure=True,
     ),
     PrecisionTestCase(
         search_terms="mammas favorites",
@@ -115,6 +117,7 @@ test_cases = [
             "Searching for a token without its possessive should match a "
             "document with"
         ),
+        known_failure=True,
     ),
     PrecisionTestCase(
         search_terms="sophies shell",

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -145,7 +145,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_precision(test_case: PrecisionTestCase, pipeline_client, works_search):
     response = pipeline_client.search(

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -64,7 +64,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize(
-    "test_case", test_cases, ids=[tc.id for tc in test_cases]
+    "test_case", [test_case.param for test_case in test_cases]
 )
 def test_recall(test_case: RecallTestCase, pipeline_client, works_search):
     response = pipeline_client.search(

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -39,26 +39,31 @@ test_cases = [
         search_terms="eugenics society annual reports",
         expected_ids=["k9w95csw", "asqf8kzb", "n499pzsr"],
         description="Matches archives without providing refnos",
+        known_failure=True,
     ),
     RecallTestCase(
         search_terms="لكشف",
         expected_ids=["ymnmz59p"],
         description="Matches stemmed arabic text",
+        known_failure=True,
     ),
     RecallTestCase(
         search_terms="الكشف",
         expected_ids=["ymnmz59p"],
         description="Matches arabic text",
+        known_failure=True,
     ),
     RecallTestCase(
         search_terms="معرفت",
         expected_ids=["a9w79fzj"],
         description="Matches arabic text",
+        known_failure=True,
     ),
     RecallTestCase(
         search_terms="عرف",
         expected_ids=["a9w79fzj"],
         description="Matches stemmed arabic text",
+        known_failure=True,
     ),
 ]
 


### PR DESCRIPTION
This PR adds a `known_failure` argument to the `TestCase` class, and uses it in each of the relevant cases.

When running the test suite, you should now see:

```
$ poetry run rank test
===================================== test session starts ======================================
collected 78 items                                                                             

cli/relevance_tests/images/test_alternative_spellings.py .xx                             [  3%]
cli/relevance_tests/images/test_precision.py ....                                        [  8%]
cli/relevance_tests/images/test_recall.py ...                                            [ 12%]
cli/relevance_tests/works/test_alternative_spellings.py .....xxxxxx..xxxxxx.xx           [ 41%]
cli/relevance_tests/works/test_order.py xx........x..                                    [ 57%]
cli/relevance_tests/works/test_precision.py ........x......x..x...                       [ 85%]
cli/relevance_tests/works/test_recall.py ......xxxxx                                     [100%]

=============================== 51 passed, 27 xfailed in 19.72s ================================
```

I'd still like to put some time into continuous test outputs (rather than binary pass/fails), but this mirrors what we have in Old Rank for the time being.