### PR TITLE
Use Context.meta to pass sessions and clients around the CLI

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,7 +1,16 @@
+import os
 from enum import Enum
 from pathlib import Path
 
 catalogue_api_url = "https://api.wellcomecollection.org/catalogue/v2"
+
+role_arn = (
+    # Don't assume a role when running in CI.
+    # Instead, the role should be assumed by the buildkite instance
+    None
+    if os.environ.get("BUILDKITE") is not None
+    else "arn:aws:iam::760097843905:role/platform-developer"
+)
 
 
 class ContentType(str, Enum):

--- a/cli/commands/index.py
+++ b/cli/commands/index.py
@@ -1,31 +1,44 @@
-from typing import Optional
 import json
+from typing import Optional
+
 import typer
+from elasticsearch import Elasticsearch
+
+from .. import index_config_directory
+from ..services import aws, elasticsearch
 from . import (
     get_valid_indices,
-    prompt_user_to_choose_a_remote_index,
     prompt_user_to_choose_a_local_config,
+    prompt_user_to_choose_a_remote_index,
     raise_if_index_already_exists,
-    rank_client,
 )
-from .. import index_config_directory
 
 app = typer.Typer(
     name="index",
     help="Manage indices in the rank cluster",
     no_args_is_help=True,
+    add_completion=False,
 )
 
 
-@app.command()
-def list():
+@app.callback()
+def callback(context: typer.Context):
+    context.meta["session"] = aws.get_session(context.meta["role_arn"])
+    context.meta["rank_client"] = elasticsearch.rank_client(
+        context.meta["session"]
+    )
+
+
+@app.command(name="list")
+def list_indices(context: typer.Context):
     """List the indices in the rank cluster"""
-    valid_indices = get_valid_indices()
+    valid_indices = get_valid_indices(context)
     typer.echo("\n".join(valid_indices))
 
 
 @app.command()
 def create(
+    context: typer.Context,
     index: str = typer.Option(
         None,
         help="The name of the index to create",
@@ -39,7 +52,6 @@ def create(
             "If a config file is not provided, you will be prompted to select "
             "one from the index config directory"
         ),
-        callback=prompt_user_to_choose_a_local_config,
     ),
     source_index: Optional[str] = typer.Option(
         None,
@@ -48,10 +60,12 @@ def create(
             "is not provided, you will be prompted to select one from the "
             "rank cluster"
         ),
-        callback=prompt_user_to_choose_a_remote_index,
     ),
 ):
     """Create an index in the rank cluster"""
+    source_index = prompt_user_to_choose_a_remote_index(context, source_index)
+    config_path = prompt_user_to_choose_a_local_config(context, config_path)
+
     with open(config_path, "r", encoding="utf-8") as f:
         config = json.load(f)
 
@@ -72,21 +86,22 @@ def create(
             },
             wait_for_completion=False,
         )
-        typer.echo(f"Reindex task {task['task']} started")
+        task_id = task["task"]
+        typer.echo(f"Reindex task {task_id} started")
         typer.echo(
-            f"Run `rank task status {task['task']}` to monitor its progress"
+            f"Run `rank task status --task-id={task_id}` to monitor its progress"
         )
 
 
 @app.command()
 def update(
+    context: typer.Context,
     index: str = typer.Option(
         None,
         help=(
             "The name of the index to update. If an index is not provided, you "
             "will be prompted to select one from the rank cluster"
         ),
-        callback=prompt_user_to_choose_a_remote_index,
     ),
     config_path: Optional[str] = typer.Option(
         None,
@@ -95,13 +110,16 @@ def update(
             "If a config file is not provided, you will be prompted to select "
             "one from the index config directory"
         ),
-        callback=prompt_user_to_choose_a_local_config,
     ),
 ):
     """Update an index in the rank cluster"""
+    index = prompt_user_to_choose_a_remote_index(context, index)
+    config_path = prompt_user_to_choose_a_local_config(context, config_path)
+
     with open(config_path, "r", encoding="utf-8") as f:
         config = json.load(f)
 
+    rank_client: Elasticsearch = context.meta["rank_client"]
     rank_client.indices.put_settings(index=index, body=config["settings"])
     rank_client.indices.put_mapping(index=index, body=config["mappings"])
     typer.echo(f"{index} updated")
@@ -112,24 +130,26 @@ def update(
         task = rank_client.update_by_query(
             index=index, wait_for_completion=False
         )
-        typer.echo(f"Update task {task['task']} started")
+        task_id = task["task"]
+        typer.echo(f"Update task {task_id} started")
         typer.echo(
-            f"Run `rank task status {task['task']}` to monitor its progress"
+            f"Run `rank task status --task-id={task_id}` to monitor its progress"
         )
 
 
 @app.command(help="Delete an index")
 def delete(
+    context: typer.Context,
     index: str = typer.Option(
         None,
         help=(
             "The name of the index to delete. If an index is not provided, you "
             "will be prompted to select one from the rank cluster"
         ),
-        callback=prompt_user_to_choose_a_remote_index,
     ),
 ):
     """Delete an index from the rank cluster"""
+    index = prompt_user_to_choose_a_remote_index(context, index)
     if typer.confirm(f"Are you sure you want to delete {index}?", abort=True):
         rank_client.indices.delete(index=index)
         typer.echo(f"{index} deleted")
@@ -137,6 +157,7 @@ def delete(
 
 @app.command()
 def get(
+    context: typer.Context,
     index: str = typer.Option(
         None,
         help=(
@@ -144,10 +165,11 @@ def get(
             "not provided, you will be prompted to select one from the rank "
             "cluster"
         ),
-        callback=prompt_user_to_choose_a_remote_index,
     ),
 ):
     """Get the mappings and settings for an index in the rank cluster"""
+    index = prompt_user_to_choose_a_remote_index(context, index)
+    rank_client: Elasticsearch = context.meta["rank_client"]
     config = dict(rank_client.indices.get(index=index))[index]
     # only keep the analysis section of the settings
     config["settings"] = {

--- a/cli/commands/query.py
+++ b/cli/commands/query.py
@@ -1,8 +1,10 @@
 import json
+
 import beaupy
 import requests
 import typer
-from .. import query_directory, catalogue_api_url
+
+from .. import catalogue_api_url, query_directory
 from . import get_valid_queries
 
 app = typer.Typer(
@@ -12,16 +14,20 @@ app = typer.Typer(
 )
 
 
-@app.command()
-def list():
+@app.command(name="list")
+def list_queries(
+    context: typer.Context,
+):
     """List the queries in the query directory"""
-    queries = get_valid_queries()
+    queries = get_valid_queries(context)
     for query in queries:
         typer.echo(query.name)
 
 
 @app.command()
-def get():
+def get(
+    context: typer.Context,
+):
     """
     Get the prod queries from the API
 

--- a/cli/commands/task.py
+++ b/cli/commands/task.py
@@ -1,9 +1,12 @@
 import time
 from typing import Optional
+
 import typer
-from . import rank_client, prompt_user_to_choose_a_task, get_valid_tasks
+from elasticsearch import Elasticsearch
 from rich.progress import Progress
 
+from ..services import aws, elasticsearch
+from . import get_valid_tasks, prompt_user_to_choose_a_task
 
 app = typer.Typer(
     name="task",
@@ -12,16 +15,27 @@ app = typer.Typer(
 )
 
 
+@app.callback()
+def callback(context: typer.Context):
+    context.meta["session"] = aws.get_session(context.meta["role_arn"])
+    context.meta["rank_client"] = elasticsearch.rank_client(
+        context.meta["session"]
+    )
+
+
 @app.command(name="list")
-def list_tasks():
+def list_tasks(
+    context: typer.Context,
+):
     """List all tasks"""
-    tasks = get_valid_tasks()
+    tasks = get_valid_tasks(context)
     for task in tasks:
         typer.echo(f'{task["task_id"]} | {task["action"]}')
 
 
 @app.command()
 def status(
+    context: typer.Context,
     task_id: Optional[str] = typer.Option(
         None,
         help=(
@@ -29,9 +43,10 @@ def status(
             "from a list of running tasks"
         ),
         callback=prompt_user_to_choose_a_task,
-    )
+    ),
 ):
     """Get the status of a task"""
+    rank_client: Elasticsearch = context.meta["rank_client"]
     task = rank_client.tasks.get(task_id=task_id)
     with Progress() as progress:
         task_progress = progress.add_task(
@@ -54,6 +69,7 @@ def status(
 
 @app.command()
 def cancel(
+    context: typer.Context,
     task: Optional[str] = typer.Option(
         None,
         help=(
@@ -61,8 +77,9 @@ def cancel(
             "from a list of running tasks"
         ),
         callback=prompt_user_to_choose_a_task,
-    )
+    ),
 ):
     """Cancel a task"""
     if typer.confirm(f"Are you sure you want to cancel {task}?", abort=True):
+        rank_client: Elasticsearch = context.meta["rank_client"]
         rank_client.tasks.cancel(task_id=task)

--- a/cli/commands/test.py
+++ b/cli/commands/test.py
@@ -1,9 +1,10 @@
+from pathlib import Path
+
 import pytest
 import typer
 from typing_extensions import Annotated
-from pathlib import Path
-from .. import ContentType, catalogue_api_url
 
+from .. import ContentType
 from ..plugin import RankPlugin
 
 app = typer.Typer(name="test", help="Run relevance tests")
@@ -13,7 +14,7 @@ root_test_directory = Path("cli/relevance_tests/")
 
 @app.callback(invoke_without_command=True)
 def main(
-    ctx: typer.Context,
+    context: typer.Context,
     test_id: Annotated[
         str,
         typer.Option(
@@ -36,12 +37,8 @@ def main(
     ] = None,
 ):
     """Run relevance tests"""
-    if ctx.invoked_subcommand is None:
-        rank_plugin = RankPlugin(
-            role_arn="arn:aws:iam::760097843905:role/platform-developer",
-            catalogue_api_url=catalogue_api_url,
-        )
-
+    if context.invoked_subcommand is None:
+        rank_plugin = RankPlugin(context=context)
         test_directory = root_test_directory
         if content_type:
             test_directory = test_directory / content_type
@@ -55,7 +52,7 @@ def main(
         raise typer.Exit(code=return_code)
 
 
-@app.command()
-def list():
+@app.command(name="list")
+def list_tests():
     """List all tests that can be run"""
     pytest.main(["--collect-only", "--quiet", root_test_directory])

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,5 +1,6 @@
 import typer
 
+from . import role_arn
 from .commands import index, query, search, task, test
 
 app = typer.Typer(
@@ -8,6 +9,12 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+
+@app.callback()
+def callback(context: typer.Context):
+    context.meta["role_arn"] = role_arn
+
 
 app.add_typer(test.app)
 app.add_typer(index.app)

--- a/cli/plugin.py
+++ b/cli/plugin.py
@@ -5,8 +5,10 @@ import boto3
 import chevron
 import pytest
 import requests
+import typer
 from elasticsearch import Elasticsearch
 
+from . import catalogue_api_url
 from .services import aws, elasticsearch
 
 
@@ -42,13 +44,13 @@ class SearchUnderTest:
 
 
 class RankPlugin:
-    def __init__(self, *, role_arn: str, catalogue_api_url: str):
-        self.role_arn = role_arn
+    def __init__(self, *, context: typer.Context):
+        self.role_arn = context.meta["role_arn"]
         self.sut = SearchUnderTest(catalogue_api_url)
 
     @pytest.fixture(scope="session")
     def aws_session(self) -> boto3.session.Session:
-        return aws.get_session(role_arn=self.role_arn)
+        return aws.get_session(self.role_arn)
 
     @pytest.fixture(scope="session")
     def pipeline_client(self, aws_session) -> Elasticsearch:

--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -2,7 +2,6 @@ import pytest
 
 from ..models import RecallTestCase
 
-
 test_cases = [
     RecallTestCase(
         search_terms="arbeiten",

--- a/cli/relevance_tests/models.py
+++ b/cli/relevance_tests/models.py
@@ -1,6 +1,6 @@
-import pytest
-from typing import List, Optional, ClassVar
+from typing import ClassVar, List, Optional
 
+import pytest
 from pydantic import BaseModel, Field, model_validator
 
 

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -1,4 +1,5 @@
 import pytest
+
 from ..models import OrderTestCase
 
 test_cases = [


### PR DESCRIPTION
The `rank test` command uses some very neat pytest features to minimise the number of times we create aws sessions, fetch secrets, and create elasticsearch clients.

This PR brings the `rank test` command and the rest of the CLI closer together by sharing some of that context and more neatly handling sessions and clients throughout the app.

I've shuffled the way that typer callbacks and contexts are invoked, and have taken advantage of click's `Context.meta` object ([docs here](https://click.palletsprojects.com/en/8.1.x/api/#click.Context.meta)), allowing us to pass a single `role_arn` down from the top-level typer app, and to create aws sessions and elasticsearch clients only when needed by the subcommand in question.