### PR TITLE
Test local queries

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -4,7 +4,8 @@ import os
 from enum import Enum
 from pathlib import Path
 
-catalogue_api_url = "https://api.wellcomecollection.org/catalogue/v2"
+production_api_url = "https://api.wellcomecollection.org/catalogue/v2"
+staging_api_url = "https://api-stage.wellcomecollection.org/catalogue/v2"
 
 role_arn = (
     # Don't assume a role when running in CI.
@@ -32,9 +33,9 @@ query_directory = data_directory / "queries"
 term_directory = data_directory / "terms"
 
 
-def get_pipeline_search_templates(catalogue_api_url: str) -> dict:
+def get_pipeline_search_templates(api_url: str) -> dict:
     search_templates = requests.get(
-        f"{catalogue_api_url}/search-templates.json",
+        f"{api_url}/search-templates.json",
         timeout=10,
     ).json()["templates"]
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,8 +1,9 @@
-import re
-import requests
 import os
+import re
 from enum import Enum
 from pathlib import Path
+
+import requests
 
 production_api_url = "https://api.wellcomecollection.org/catalogue/v2"
 staging_api_url = "https://api-stage.wellcomecollection.org/catalogue/v2"

--- a/cli/commands/__init__.py
+++ b/cli/commands/__init__.py
@@ -4,7 +4,14 @@ import beaupy
 import typer
 from elasticsearch import Elasticsearch
 
-from .. import ContentType, Environment, index_config_directory, query_directory
+from .. import (
+    ContentType,
+    Environment,
+    index_config_directory,
+    query_directory,
+    production_api_url,
+    staging_api_url,
+)
 
 
 def get_valid_indices(client: Elasticsearch):
@@ -167,6 +174,7 @@ def prompt_user_to_choose_a_content_type(
 
 
 def prompt_user_to_choose_an_environment(
+    context: typer.Context,
     environment: Optional[Environment],
 ) -> Environment:
     valid_environments = [environment.value for environment in Environment]
@@ -178,6 +186,12 @@ def prompt_user_to_choose_an_environment(
             raise typer.BadParameter(
                 f"{environment} is not a valid environment"
             )
+
+    if environment == Environment.PRODUCTION:
+        context.meta["api_url"] = production_api_url
+    elif environment == Environment.STAGING:
+        context.meta["api_url"] = staging_api_url
+
     return Environment(environment)
 
 

--- a/cli/commands/index.py
+++ b/cli/commands/index.py
@@ -5,7 +5,11 @@ from typing import Optional
 import typer
 from elasticsearch import Elasticsearch
 
-from .. import index_config_directory, get_pipeline_search_templates
+from .. import (
+    index_config_directory,
+    get_pipeline_search_templates,
+    production_api_url,
+)
 from ..services import aws, elasticsearch
 from . import (
     get_valid_indices,
@@ -233,9 +237,7 @@ def replicate(
         ),
         abort=True,
     ):
-        search_templates = get_pipeline_search_templates(
-            context.meta["catalogue_api_url"]
-        )
+        search_templates = get_pipeline_search_templates(production_api_url)
         content_type = context.meta.get("content_type", "works")
         pipeline_date = search_templates[content_type]["index_date"]
 

--- a/cli/commands/search.py
+++ b/cli/commands/search.py
@@ -175,6 +175,7 @@ def main(
         context.meta["environment"] = prompt_user_to_choose_an_environment(
             environment
         )
+
         context.meta["content_type"] = prompt_user_to_choose_a_content_type(
             content_type
         )
@@ -194,7 +195,7 @@ def main(
         else:
             context.meta["client"] = elasticsearch.pipeline_client(context)
             search_templates = get_pipeline_search_templates(
-                context.meta["catalogue_api_url"]
+                context.meta["api_url"]
             )
             context.meta["query_template"] = search_templates[
                 context.meta["content_type"]

--- a/cli/commands/search.py
+++ b/cli/commands/search.py
@@ -6,12 +6,18 @@ import chevron
 import rich
 import typer
 
-from .. import ContentType, term_directory
+from .. import (
+    ContentType,
+    term_directory,
+    Environment,
+    get_pipeline_search_templates,
+)
 from ..services import aws, elasticsearch
 from . import (
     prompt_user_to_choose_a_content_type,
     prompt_user_to_choose_a_local_query,
-    prompt_user_to_choose_a_remote_index,
+    prompt_user_to_choose_an_environment,
+    prompt_user_to_choose_an_index,
 )
 
 app = typer.Typer(
@@ -26,6 +32,10 @@ app = typer.Typer(
 
         The command will output a table of results with the following columns:\n
         Score, ID, Title, Dates, Reference number
+
+        If you want to run the search against the production/staging index,
+        you should specify eg --environment=production. In this case, index 
+        and query selection will be handled automatically.
         """
     ),
 )
@@ -130,75 +140,98 @@ def build_images_results_table(response: dict) -> rich.table.Table:
 def main(
     context: typer.Context,
     search_terms: Optional[str] = typer.Option(
-        None,
+        default=None,
         help="The search terms to use",
     ),
+    environment: Optional[Environment] = typer.Option(
+        default="development",
+        help="The environment to run the search against",
+        case_sensitive=False,
+        show_choices=True,
+    ),
+    content_type: Optional[ContentType] = typer.Option(
+        default=None,
+        help="The content type to search in",
+        case_sensitive=False,
+        show_choices=True,
+    ),
     index: Optional[str] = typer.Option(
-        None,
+        default=None,
         help="The index to search in",
     ),
     query_path: Optional[str] = typer.Option(
-        None,
+        default=None,
         help="The query to run",
     ),
     n: Optional[int] = typer.Option(
-        10,
+        default=10,
         help="The number of results to return",
         min=1,
         max=100,
     ),
 ):
-    context.meta["session"] = aws.get_session(context.meta["role_arn"])
-    context.meta["rank_client"] = elasticsearch.rank_client(
-        context.meta["session"]
-    )
-
     if context.invoked_subcommand is None:
-        # We shouldn't use callbacks here, because the main() command itself is
-        # a callback. If a user tries to run eg `rank search get-terms` with
-        # callbacks specified in the parameters of main(), those callbacks
-        # will be run before the subcommand is invoked. This means that the user
-        # will be prompted to choose an index and query for subcommands that
-        # don't need them. Instead, we'll just prompt the user here if they
-        # haven't provided the necessary arguments.
+        context.meta["session"] = aws.get_session(context.meta["role_arn"])
+        context.meta["environment"] = prompt_user_to_choose_an_environment(
+            environment
+        )
+        context.meta["content_type"] = prompt_user_to_choose_a_content_type(
+            content_type
+        )
+        if context.meta["environment"] == Environment.DEVELOPMENT:
+            context.meta["client"] = elasticsearch.rank_client(context)
+            query_path = prompt_user_to_choose_a_local_query(
+                context=context,
+                content_type=context.meta["content_type"],
+            )
+            with open(query_path, "r", encoding="utf-8") as f:
+                query_template = json.dumps(json.load(f))
+            context.meta["index"] = prompt_user_to_choose_an_index(
+                context=context,
+                index=index,
+                content_type=context.meta["content_type"],
+            )
+        else:
+            context.meta["client"] = elasticsearch.pipeline_client(context)
+            search_templates = get_pipeline_search_templates(
+                context.meta["catalogue_api_url"]
+            )
+            context.meta["query_template"] = search_templates[
+                context.meta["content_type"]
+            ]["query"]
+            context.meta["index"] = search_templates[
+                context.meta["content_type"]
+            ]["index"]
+
         if search_terms is None:
             search_terms = typer.prompt("What are you looking for?")
-        index = prompt_user_to_choose_a_remote_index(
-            context=context, index=index
-        )
-        query_path = prompt_user_to_choose_a_local_query(
-            context=context, query_path=query_path
-        )
 
-        content_type = ContentType(index.split("-")[0])
+        rendered_query = chevron.render(query_template, {"query": search_terms})
 
-        with open(query_path, "r", encoding="utf-8") as f:
-            query = json.dumps(json.load(f))
-
-        rendered_query = chevron.render(query, {"query": search_terms})
-
-        response = context.meta["rank_client"].search(
-            index=index,
+        response = context.meta["client"].search(
+            index=context.meta["index"],
             query=json.loads(rendered_query),
             size=n,
             source=["display"],
         )
 
-        table = build_results_table(response, content_type)
+        table = build_results_table(response, context.meta["content_type"])
         rich.print(table)
 
 
 @app.command()
 def get_terms(
     context: typer.Context,
-    content_type: Optional[ContentType] = typer.Option(
+    content_type: ContentType = typer.Option(
         None,
         help="The content type to find real search terms for",
-        callback=prompt_user_to_choose_a_content_type,
     ),
 ):
     """Get a list of real search terms for a given content type"""
-    reporting_client = elasticsearch.reporting_client(context.meta["session"])
+    reporting_client = elasticsearch.reporting_client(context=context)
+
+    if content_type is None:
+        content_type = prompt_user_to_choose_a_content_type(content_type)
 
     # Page names and content types are currently the same but we don't want to
     # rely on that

--- a/cli/commands/test.py
+++ b/cli/commands/test.py
@@ -50,7 +50,7 @@ def main(
     if context.invoked_subcommand is None:
         context.meta["session"] = aws.get_session(context.meta["role_arn"])
         context.meta["environment"] = prompt_user_to_choose_an_environment(
-            environment
+            context, environment
         )
         context.meta["content_type"] = prompt_user_to_choose_a_content_type(
             content_type
@@ -71,7 +71,7 @@ def main(
         else:
             context.meta["client"] = elasticsearch.pipeline_client(context)
             search_templates = get_pipeline_search_templates(
-                context.meta["catalogue_api_url"]
+                context.meta["api_url"]
             )
             context.meta["query_template"] = json.loads(
                 search_templates[context.meta["content_type"]]["query"]

--- a/cli/commands/test.py
+++ b/cli/commands/test.py
@@ -1,58 +1,101 @@
+import json
+from typing import Optional
 from pathlib import Path
 
 import pytest
 import typer
-from typing_extensions import Annotated
 
-from .. import ContentType
+from .. import ContentType, Environment, get_pipeline_search_templates
+from . import (
+    prompt_user_to_choose_an_environment,
+    prompt_user_to_choose_a_local_query,
+    prompt_user_to_choose_an_index,
+    prompt_user_to_choose_a_content_type,
+)
+from ..services import aws, elasticsearch
 from ..plugin import RankPlugin
 
 app = typer.Typer(name="test", help="Run relevance tests")
 
-root_test_directory = Path("cli/relevance_tests/")
+root_test_dir = Path("cli/relevance_tests/")
 
 
 @app.callback(invoke_without_command=True)
 def main(
     context: typer.Context,
-    test_id: Annotated[
-        str,
-        typer.Option(
-            "--id",
-            "--group",
-            "-g",
-            help="The ID of an individual test (or group of tests) to run.",
-            case_sensitive=False,
-        ),
-    ] = None,
-    content_type: Annotated[
-        ContentType,
-        typer.Option(
-            "--content-type",
-            "-c",
-            help="The content type to run tests for",
-            case_sensitive=False,
-            show_choices=True,
-        ),
-    ] = None,
+    test_id: Optional[str] = typer.Option(
+        help="The ID of an individual test (or group of tests) to run.",
+        case_sensitive=False,
+        default=None,
+    ),
+    content_type: Optional[ContentType] = typer.Option(
+        help="The content type to run tests for",
+        case_sensitive=False,
+        show_choices=True,
+        default=None,
+    ),
+    environment: Optional[Environment] = typer.Option(
+        help="The environment to run tests against",
+        case_sensitive=False,
+        show_choices=True,
+        default="development",
+    ),
+    index: Optional[str] = typer.Option(
+        help="The index to run tests against",
+        case_sensitive=False,
+        default=None,
+    ),
 ):
     """Run relevance tests"""
     if context.invoked_subcommand is None:
+        context.meta["session"] = aws.get_session(context.meta["role_arn"])
+        context.meta["environment"] = prompt_user_to_choose_an_environment(
+            environment
+        )
+        context.meta["content_type"] = prompt_user_to_choose_a_content_type(
+            content_type
+        )
+
+        if context.meta["environment"] == Environment.DEVELOPMENT:
+            context.meta["client"] = elasticsearch.rank_client(context)
+            query_template_path = prompt_user_to_choose_a_local_query(
+                context=context,
+                content_type=context.meta["content_type"],
+            )
+            with open(query_template_path) as f:
+                context.meta["query_template"] = json.load(f)
+
+            context.meta["index"] = prompt_user_to_choose_an_index(
+                context, index, content_type=context.meta["content_type"]
+            )
+        else:
+            context.meta["client"] = elasticsearch.pipeline_client(context)
+            search_templates = get_pipeline_search_templates(
+                context.meta["catalogue_api_url"]
+            )
+            context.meta["query_template"] = json.loads(
+                search_templates[context.meta["content_type"]]["query"]
+            )
+            context.meta["index"] = search_templates[
+                context.meta["content_type"]
+            ]["index"]
+
         rank_plugin = RankPlugin(context=context)
-        test_directory = root_test_directory
-        if content_type:
-            test_directory = test_directory / content_type
+
+        test_dir = root_test_dir / context.meta["content_type"].value
 
         if test_id:
             return_code = pytest.main(
-                [test_directory, "-k", test_id], plugins=[rank_plugin]
+                [test_dir, "-k", test_id], plugins=[rank_plugin]
             )
+
         else:
-            return_code = pytest.main([test_directory], plugins=[rank_plugin])
+            return_code = pytest.main([test_dir], plugins=[rank_plugin])
+
         raise typer.Exit(code=return_code)
 
 
 @app.command(name="list")
 def list_tests():
     """List all tests that can be run"""
-    pytest.main(["--collect-only", "--quiet", root_test_directory])
+    pytest.main(["--collect-only", "--quiet", root_test_dir])

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,6 @@
 import typer
 
-from . import catalogue_api_url, role_arn
+from . import role_arn
 from .commands import index, query, search, task, test
 
 app = typer.Typer(
@@ -14,7 +14,6 @@ app = typer.Typer(
 @app.callback()
 def callback(context: typer.Context):
     context.meta["role_arn"] = role_arn
-    context.meta["catalogue_api_url"] = catalogue_api_url
 
 
 app.add_typer(test.app)

--- a/cli/plugin.py
+++ b/cli/plugin.py
@@ -1,107 +1,32 @@
 import json
-import re
 
-import boto3
 import chevron
-import pytest
-import requests
+from pytest import fixture
+
 import typer
 from elasticsearch import Elasticsearch
-
-from .services import aws, elasticsearch
-
-
-def get_pipeline_search_templates(catalogue_api_url: str) -> dict:
-    search_templates = requests.get(
-        f"{catalogue_api_url}/search-templates.json",
-        timeout=10,
-    ).json()["templates"]
-
-    works = next(
-        template
-        for template in search_templates
-        if template["index"].startswith("works")
-    )
-    images = next(
-        template
-        for template in search_templates
-        if template["index"].startswith("images")
-    )
-
-    return {
-        "works": {
-            "index": works["index"],
-            "index_date": re.search(
-                r"^works-indexed-(?P<date>\d{4}-\d{2}-\d{2}.?)",
-                works["index"],
-            ).group("date"),
-            "query": works["query"],
-        },
-        "images": {
-            "index": images["index"],
-            "index_date": re.search(
-                r"^images-indexed-(?P<date>\d{4}-\d{2}-\d{2}.?)",
-                images["index"],
-            ).group("date"),
-            "query": images["query"],
-        },
-    }
-
-
-class SearchUnderTest:
-    pipeline_date: str
-    works_query_template: str
-    works_index: str
-    images_query_template: str
-    images_index: str
-
-    def __init__(self, catalogue_api_url: str):
-        search_templates = get_pipeline_search_templates(catalogue_api_url)
-        self.pipeline_date = search_templates["works"]["index_date"]
-        self.works_query_template = search_templates["works"]["query"]
-        self.works_index = search_templates["works"]["index"]
-        self.images_query_template = search_templates["images"]["query"]
-        self.images_index = search_templates["images"]["index"]
 
 
 class RankPlugin:
     def __init__(self, *, context: typer.Context):
-        self.role_arn = context.meta["role_arn"]
-        self.catalogue_api_url = context.meta["catalogue_api_url"]
-        self.sut = SearchUnderTest(self.catalogue_api_url)
+        self._client = context.meta["client"]
+        self._index = context.meta["index"]
+        self._query_template = json.dumps(context.meta["query_template"])
 
-    @pytest.fixture(scope="session")
-    def aws_session(self) -> boto3.session.Session:
-        return aws.get_session(self.role_arn)
+    @fixture(scope="session")
+    def client(self) -> Elasticsearch:
+        return self._client
 
-    @pytest.fixture(scope="session")
-    def pipeline_client(self, aws_session) -> Elasticsearch:
-        return elasticsearch.pipeline_client(
-            aws_session, pipeline_date=self.sut.pipeline_date
-        )
+    @fixture(scope="session")
+    def index(self) -> str:
+        return self._index
 
-    @pytest.fixture()
-    def works_search(self):
-        def _get_search_params(search_terms: str):
+    @fixture()
+    def render_query(self):
+        def _render_query(search_terms: str):
             rendered = chevron.render(
-                self.sut.works_query_template, {"query": search_terms}
+                self._query_template, {"query": search_terms}
             )
-            return {
-                "query": json.loads(rendered),
-                "index": self.sut.works_index,
-            }
+            return json.loads(rendered)
 
-        return _get_search_params
-
-    @pytest.fixture()
-    def images_search(self):
-        def _get_search_params(search_terms: str):
-            rendered = chevron.render(
-                self.sut.images_query_template, {"query": search_terms}
-            )
-            return {
-                "query": json.loads(rendered),
-                "index": self.sut.images_index,
-            }
-
-        return _get_search_params
+        return _render_query

--- a/cli/plugin.py
+++ b/cli/plugin.py
@@ -1,10 +1,9 @@
 import json
 
 import chevron
-from pytest import fixture
-
 import typer
 from elasticsearch import Elasticsearch
+from pytest import fixture
 
 
 class RankPlugin:

--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -27,10 +27,11 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_alternative_spellings(
-    test_case: RecallTestCase, pipeline_client, images_search
+    test_case: RecallTestCase, client, index, render_query
 ):
-    response = pipeline_client.search(
-        **images_search(test_case.search_terms),
+    response = client.search(
+        query=render_query(test_case.search_terms),
+        index=index,
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/relevance_tests/images/test_precision.py
+++ b/cli/relevance_tests/images/test_precision.py
@@ -30,11 +30,10 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_precision(
-    test_case: PrecisionTestCase, pipeline_client, images_search
-):
-    response = pipeline_client.search(
-        **images_search(test_case.search_terms),
+def test_precision(test_case: PrecisionTestCase, client, index, render_query):
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -57,9 +57,10 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_recall(test_case: RecallTestCase, pipeline_client, images_search):
-    response = pipeline_client.search(
-        **images_search(test_case.search_terms),
+def test_recall(test_case: RecallTestCase, client, index, render_query):
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -226,10 +226,11 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_alternative_spellings(
-    test_case: RecallTestCase, pipeline_client, works_search
+    test_case: RecallTestCase, client, index, render_query
 ):
-    response = pipeline_client.search(
-        **works_search(test_case.search_terms),
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -93,9 +93,10 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_order(test_case: OrderTestCase, pipeline_client, works_search):
-    response = pipeline_client.search(
-        **works_search(test_case.search_terms),
+def test_order(test_case: OrderTestCase, client, index, render_query):
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -150,9 +150,10 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_precision(test_case: PrecisionTestCase, pipeline_client, works_search):
-    response = pipeline_client.search(
-        **works_search(test_case.search_terms),
+def test_precision(test_case: PrecisionTestCase, client, index, render_query):
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -71,9 +71,10 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_recall(test_case: RecallTestCase, pipeline_client, works_search):
-    response = pipeline_client.search(
-        **works_search(test_case.search_terms),
+def test_recall(test_case: RecallTestCase, client, index, render_query):
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
         size=test_case.threshold_position,
         _source=False,
     )

--- a/cli/services/elasticsearch.py
+++ b/cli/services/elasticsearch.py
@@ -1,16 +1,21 @@
+import typer
 from time import sleep
 
-import boto3
+
+from .. import get_pipeline_search_templates
 from elasticsearch import Elasticsearch
 
 from .aws import get_secrets
 
 
-def pipeline_client(
-    session: boto3.session.Session, *, pipeline_date: str
-) -> Elasticsearch:
+def pipeline_client(context: typer.Context) -> Elasticsearch:
+    search_templates = get_pipeline_search_templates(
+        context.meta["catalogue_api_url"]
+    )
+    content_type = context.meta.get("content_type", "works")
+    pipeline_date = search_templates[content_type]["index_date"]
     secrets = get_secrets(
-        session=session,
+        session=context.meta["session"],
         secret_prefix=f"elasticsearch/pipeline_storage_{pipeline_date}/",
         secret_ids=[
             "es_password",
@@ -29,9 +34,9 @@ def pipeline_client(
     return client
 
 
-def rank_client(session: boto3.session.Session) -> Elasticsearch:
+def rank_client(context: typer.Context) -> Elasticsearch:
     secrets = get_secrets(
-        session=session,
+        session=context.meta["session"],
         secret_prefix="elasticsearch/rank/",
         secret_ids=["ES_RANK_PASSWORD", "ES_RANK_USER", "ES_RANK_CLOUD_ID"],
     )
@@ -44,11 +49,9 @@ def rank_client(session: boto3.session.Session) -> Elasticsearch:
     return client
 
 
-def reporting_client(
-    session: boto3.session.Session,
-) -> Elasticsearch:
+def reporting_client(context: typer.Context) -> Elasticsearch:
     secrets = get_secrets(
-        session=session,
+        session=context.meta["session"],
         secret_prefix="reporting/",
         secret_ids=[
             "es_host",

--- a/cli/services/elasticsearch.py
+++ b/cli/services/elasticsearch.py
@@ -9,9 +9,7 @@ from .aws import get_secrets
 
 
 def pipeline_client(context: typer.Context) -> Elasticsearch:
-    search_templates = get_pipeline_search_templates(
-        context.meta["catalogue_api_url"]
-    )
+    search_templates = get_pipeline_search_templates(context.meta["api_url"])
     content_type = context.meta.get("content_type", "works")
     pipeline_date = search_templates[content_type]["index_date"]
     secrets = get_secrets(


### PR DESCRIPTION
This PR should allow users to run `rank test` against `--environment=production`, `=staging`, and `=development`.

In most cases where the commands are actually being written, you'll be testing against the rank cluster (not prod/staging), so I've set the default environment to `development`. 

Prod/staging tests will automatically use the index/query specified by the API, but dev tests will allow users to choose from appropriate indexes in the rank cluster, and local queries.

As a result of all of the above, I've also brought the code for testing and index-management commands a bit closer together by moving some of the clever logic out of the `RankPlugin`, and making more use of typer's `context.meta`.