### PR TITLE
removes image ids for images that were taken out of the catalogue

### DIFF
--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -7,14 +7,11 @@ test_cases = [
     RecallTestCase(
         search_terms="everest chest",
         expected_ids=[
-            "bt9yvss2",
             "erth8sur",
             "fddgu7pe",
             "qbvq42t6",
             "u6ejpuxu",
             "xskq2fsc",
-            "prrq5ajp",
-            "zw53jx3j",
         ],
     ),
     RecallTestCase(


### PR DESCRIPTION
Removing images from tests that were taken down as part of the Brought to Life/Science Museum take-down