### PR TITLE
Improve rank resilience and performance

### DIFF
--- a/cli/relevance_tests/executors.py
+++ b/cli/relevance_tests/executors.py
@@ -36,7 +36,9 @@ def do_test_recall(test_case: RecallTestCase, client, index, render_query):
         )
 
 
-def do_test_precision(test_case: PrecisionTestCase, client, index, render_query):
+def do_test_precision(
+    test_case: PrecisionTestCase, client, index, render_query
+):
     expected_ids = test_case.expected_ids
     response = client.search(
         index=index,
@@ -61,7 +63,9 @@ def do_test_precision(test_case: PrecisionTestCase, client, index, render_query)
 def do_test_order(test_case: OrderTestCase, client, index, render_query):
     before_ids = set(test_case.before_ids)
     after_ids = set(test_case.after_ids)
-    assert not before_ids.intersection(after_ids), "before and after IDs must be disjoint!"
+    assert not before_ids.intersection(
+        after_ids
+    ), "before and after IDs must be disjoint!"
 
     results = elasticsearch.helpers.scan(
         client,
@@ -69,9 +73,7 @@ def do_test_order(test_case: OrderTestCase, client, index, render_query):
         index=index,
         _source=False,
         size=scan_page_size,
-        query={
-            "query": render_query(test_case.search_terms)
-        },
+        query={"query": render_query(test_case.search_terms)},
     )
 
     failures = []
@@ -97,13 +99,16 @@ def do_test_order(test_case: OrderTestCase, client, index, render_query):
     except AssertionError:
         pytest.fail(
             f"{before_ids.union(after_ids)} not found in search results.",
-            test_case.description
+            test_case.description,
         )
 
     if failures:
         failure_message = [
             test_case.description,
             "The following IDs were found in the wrong order: ",
-            *[f"{after_id} appeared before {', '.join(remaining_before)}" for remaining_before, after_id in failures]
+            *[
+                f"{after_id} appeared before {', '.join(remaining_before)}"
+                for remaining_before, after_id in failures
+            ],
         ]
         pytest.fail("\n".join(failure_message), pytrace=False)

--- a/cli/relevance_tests/executors.py
+++ b/cli/relevance_tests/executors.py
@@ -1,0 +1,109 @@
+import elasticsearch.helpers
+import pytest
+
+from .models import RecallTestCase, PrecisionTestCase, OrderTestCase
+
+scan_page_size = 250
+
+
+def do_test_recall(test_case: RecallTestCase, client, index, render_query):
+    expected_ids = set(test_case.expected_ids)
+    received_ids = set([])
+    results = elasticsearch.helpers.scan(
+        client,
+        preserve_order=True,
+        index=index,
+        _source=False,
+        size=scan_page_size,
+        query={
+            "query": render_query(test_case.search_terms),
+        },
+    )
+    for doc in results:
+        received_ids.add(doc["_id"])
+        expected_ids.discard(doc["_id"])
+
+        if not expected_ids:
+            results.close()
+        if len(received_ids) >= test_case.threshold_position:
+            results.close()
+
+    try:
+        assert not expected_ids
+    except AssertionError:
+        pytest.fail(
+            f"{expected_ids} not found in the search results: {received_ids}",
+        )
+
+
+def do_test_precision(test_case: PrecisionTestCase, client, index, render_query):
+    expected_ids = test_case.expected_ids
+    response = client.search(
+        index=index,
+        query=render_query(test_case.search_terms),
+        size=len(expected_ids),
+        _source=False,
+    )
+    result_ids = [result["_id"] for result in response["hits"]["hits"]]
+
+    if not test_case.strict:
+        result_ids = set(result_ids)
+        expected_ids = set(expected_ids)
+
+    try:
+        assert result_ids == expected_ids
+    except AssertionError:
+        pytest.fail(
+            f"The expected IDs ({expected_ids}) did not match the results ({result_ids})"
+        )
+
+
+def do_test_order(test_case: OrderTestCase, client, index, render_query):
+    before_ids = set(test_case.before_ids)
+    after_ids = set(test_case.after_ids)
+    assert not before_ids.intersection(after_ids), "before and after IDs must be disjoint!"
+
+    results = elasticsearch.helpers.scan(
+        client,
+        preserve_order=True,
+        index=index,
+        _source=False,
+        size=scan_page_size,
+        query={
+            "query": render_query(test_case.search_terms)
+        },
+    )
+
+    failures = []
+    for n, doc in enumerate(results, start=1):
+        doc_id = doc["_id"]
+
+        before_ids.discard(doc_id)
+
+        if before_ids and doc_id in after_ids:
+            failures.append((before_ids.copy(), doc_id))
+
+        after_ids.discard(doc_id)
+
+        # We don't mind if we don't see the after_ids
+        if not before_ids and not after_ids:
+            results.close()
+        if n >= test_case.threshold_position:
+            results.close()
+
+    try:
+        assert not before_ids
+        assert not after_ids
+    except AssertionError:
+        pytest.fail(
+            f"{before_ids.union(after_ids)} not found in search results.",
+            test_case.description
+        )
+
+    if failures:
+        failure_message = [
+            test_case.description,
+            "The following IDs were found in the wrong order: ",
+            *[f"{after_id} appeared before {', '.join(remaining_before)}" for remaining_before, after_id in failures]
+        ]
+        pytest.fail("\n".join(failure_message), pytrace=False)

--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ..models import RecallTestCase
+from ..executors import do_test_recall
 
 test_cases = [
     RecallTestCase(
@@ -29,18 +30,4 @@ test_cases = [
 def test_alternative_spellings(
     test_case: RecallTestCase, client, index, render_query
 ):
-    response = client.search(
-        query=render_query(test_case.search_terms),
-        index=index,
-        size=test_case.threshold_position,
-        _source=False,
-    )
-    result_ids = [result["_id"] for result in response["hits"]["hits"]]
-
-    try:
-        missing_ids = set(test_case.expected_ids) - set(result_ids)
-        assert not missing_ids
-    except AssertionError:
-        pytest.fail(
-            f"{missing_ids} not found in the search results: {result_ids}",
-        )
+    return do_test_recall(test_case, client, index, render_query)

--- a/cli/relevance_tests/images/test_precision.py
+++ b/cli/relevance_tests/images/test_precision.py
@@ -1,9 +1,7 @@
-import warnings
-
 import pytest
 
-from .. import nth
 from ..models import PrecisionTestCase
+from ..executors import do_test_precision
 
 test_cases = [
     PrecisionTestCase(
@@ -31,49 +29,4 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_precision(test_case: PrecisionTestCase, client, index, render_query):
-    response = client.search(
-        index=index,
-        query=render_query(test_case.search_terms),
-        size=test_case.threshold_position,
-        _source=False,
-    )
-    result_ids = [result["_id"] for result in response["hits"]["hits"]]
-
-    # if any of the expected IDs are missing, raise an error
-    try:
-        missing_ids = [
-            expected_id
-            for expected_id in test_case.expected_ids
-            if expected_id not in result_ids
-        ]
-        assert not missing_ids
-    except AssertionError:
-        pytest.fail(
-            f"{missing_ids} not found in the search results: {result_ids}",
-        )
-
-    # if an expected ID is between the first n positions and the threshold
-    # position, raise a warning
-    for expected_id in test_case.expected_ids:
-        if result_ids.index(expected_id) > len(test_case.expected_ids):
-            warnings.warn(
-                f"Result {expected_id} was found in position "
-                f"{result_ids.index(expected_id)}, after the "
-                f"{nth(len(test_case.expected_ids))} position, but before the "
-                f"threshold position ({test_case.threshold_position}).",
-                UserWarning,
-            )
-
-    # if the test is strict, check whether the order of the first n result IDs
-    # matches the order of the expected IDs. If they don't match, raise an error
-    if test_case.strict:
-        try:
-            assert (
-                result_ids[: test_case.threshold_position]
-                == test_case.expected_ids
-            )
-        except AssertionError:
-            pytest.fail(
-                f"The order of the expected IDs {test_case.expected_ids} "
-                f"does not match the results: {result_ids}",
-            )
+    return do_test_precision(test_case, client, index, render_query)

--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ..models import RecallTestCase
+from ..executors import do_test_recall
 
 test_cases = [
     RecallTestCase(search_terms="horse battle", expected_ids=["ud35y7c8"]),
@@ -55,18 +56,4 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_recall(test_case: RecallTestCase, client, index, render_query):
-    response = client.search(
-        index=index,
-        query=render_query(test_case.search_terms),
-        size=test_case.threshold_position,
-        _source=False,
-    )
-    result_ids = [result["_id"] for result in response["hits"]["hits"]]
-
-    try:
-        missing_ids = set(test_case.expected_ids) - set(result_ids)
-        assert not missing_ids
-    except AssertionError:
-        pytest.fail(
-            f"{missing_ids} not found in the search results: {result_ids}",
-        )
+    return do_test_recall(test_case, client, index, render_query)

--- a/cli/relevance_tests/models.py
+++ b/cli/relevance_tests/models.py
@@ -72,7 +72,6 @@ class PrecisionTestCase(TestCase):
         return self
 
 
-
 class RecallTestCase(TestCase):
     expected_ids: List[str] = Field(
         description=(

--- a/cli/relevance_tests/models.py
+++ b/cli/relevance_tests/models.py
@@ -51,16 +51,6 @@ class PrecisionTestCase(TestCase):
             "as long as they make up the first results."
         )
     )
-    threshold_position: Optional[int] = Field(
-        description=(
-            "The last possible position for the expected ID in the search "
-            "results. If None, the expected IDs must be the first results. If "
-            "specified, the expected IDs must appear at or before this "
-            "position, otherwise the test should fail. If the expected ID is "
-            "between the first and this position, the test should raise a "
-            "warning."
-        )
-    )
     strict: bool = Field(
         description=(
             "If True, the expected IDs must be the first results, in the "
@@ -71,10 +61,6 @@ class PrecisionTestCase(TestCase):
     )
 
     def __init__(self, **data):
-        # if the threshold position hasn't been specified, it should be
-        # the same as the number of expected IDs
-        if "threshold_position" not in data:
-            data["threshold_position"] = len(data["expected_ids"])
         super().__init__(**data)
 
     @model_validator(mode="after")
@@ -85,20 +71,6 @@ class PrecisionTestCase(TestCase):
             raise ValueError("expected_ids must be unique")
         return self
 
-    @model_validator(mode="after")
-    def check_threshold_position(self):
-        """Check that the threshold position is valid"""
-        if self.threshold_position is not None:
-            if self.threshold_position < 0:
-                raise ValueError(
-                    "threshold_position must be greater than or equal to 0"
-                )
-            if self.threshold_position < len(self.expected_ids):
-                raise ValueError(
-                    "threshold_position must be greater than the number of "
-                    "expected IDs"
-                )
-        return self
 
 
 class RecallTestCase(TestCase):

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -1,3 +1,4 @@
+import elasticsearch.helpers
 import pytest
 
 from ..models import OrderTestCase
@@ -94,38 +95,49 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_order(test_case: OrderTestCase, client, index, render_query):
-    response = client.search(
+    before_ids = set(test_case.before_ids)
+    after_ids = set(test_case.after_ids)
+    assert not before_ids.intersection(after_ids), "before and after IDs must be disjoint!"
+
+    results = elasticsearch.helpers.scan(client,
+        preserve_order=True,
         index=index,
-        query=render_query(test_case.search_terms),
-        size=test_case.threshold_position,
         _source=False,
+        query={
+            "query": render_query(test_case.search_terms)
+        },
     )
-    returned_ids = [hit["_id"] for hit in response["hits"]["hits"]]
 
-    # Check whether the IDs exist in the returned list
-    returned_id_set = set(returned_ids)
-    for document_id in test_case.before_ids:
-        if document_id not in returned_id_set:
-            pytest.fail(
-                f"{document_id} was not found in the results. "
-                f"{test_case.description}"
-            )
+    failures = []
+    for n, doc in enumerate(results, start=1):
+        doc_id = doc["_id"]
 
-    # Check whether all of the documents in the "after" list are after
-    # all the documents in the "before" list
-    wrong_ordered_id_pairs = []
-    for before_id in test_case.before_ids:
-        for after_id in test_case.after_ids:
-            if returned_ids.index(before_id) > returned_ids.index(after_id):
-                wrong_ordered_id_pairs.append((before_id, after_id))
+        before_ids.discard(doc_id)
 
-    if wrong_ordered_id_pairs:
+        if before_ids and doc_id in after_ids:
+            failures.append((before_ids.copy(), doc_id))
+
+        after_ids.discard(doc_id)
+
+        # We don't mind if we don't see the after_ids
+        if not before_ids and not after_ids:
+            results.close()
+        if n >= test_case.threshold_position:
+            results.close()
+
+    try:
+        assert not before_ids
+        assert not after_ids
+    except AssertionError:
+        pytest.fail(
+            f"{before_ids.union(after_ids)} not found in search results.",
+            test_case.description
+        )
+
+    if failures:
         failure_message = [
             test_case.description,
-            "The following ID pairs were found in the wrong order: ",
-            *[
-                f"{after_id} appeared before {before_id}"
-                for before_id, after_id in wrong_ordered_id_pairs
-            ],
+            "The following IDs were found in the wrong order: ",
+            *[f"{after_id} appeared before {', '.join(remaining_before)}"for remaining_before, after_id in failures]
         ]
         pytest.fail("\n".join(failure_message), pytrace=False)

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ..models import PrecisionTestCase
+from ..executors import do_test_precision
 
 test_cases = [
     PrecisionTestCase(
@@ -148,22 +149,4 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_precision(test_case: PrecisionTestCase, client, index, render_query):
-    expected_ids = test_case.expected_ids
-    response = client.search(
-        index=index,
-        query=render_query(test_case.search_terms),
-        size=len(expected_ids),
-        _source=False,
-    )
-    result_ids = [result["_id"] for result in response["hits"]["hits"]]
-
-    if not test_case.strict:
-        result_ids = set(result_ids)
-        expected_ids = set(expected_ids)
-
-    try:
-        assert result_ids == expected_ids
-    except AssertionError:
-        pytest.fail(
-           f"The expected IDs ({expected_ids}) did not match the results ({result_ids})"
-        )
+    return do_test_precision(test_case, client, index, render_query)

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -1,8 +1,5 @@
-import warnings
-
 import pytest
 
-from .. import nth
 from ..models import PrecisionTestCase
 
 test_cases = [
@@ -151,49 +148,22 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_precision(test_case: PrecisionTestCase, client, index, render_query):
+    expected_ids = test_case.expected_ids
     response = client.search(
         index=index,
         query=render_query(test_case.search_terms),
-        size=test_case.threshold_position,
+        size=len(expected_ids),
         _source=False,
     )
     result_ids = [result["_id"] for result in response["hits"]["hits"]]
 
-    # if any of the expected IDs are missing, raise an error
+    if not test_case.strict:
+        result_ids = set(result_ids)
+        expected_ids = set(expected_ids)
+
     try:
-        missing_ids = [
-            expected_id
-            for expected_id in test_case.expected_ids
-            if expected_id not in result_ids
-        ]
-        assert not missing_ids
+        assert result_ids == expected_ids
     except AssertionError:
         pytest.fail(
-            f"{missing_ids} not found in the search results: {result_ids}",
+           f"The expected IDs ({expected_ids}) did not match the results ({result_ids})"
         )
-
-    # if an expected ID is between the first n positions and the threshold
-    # position, raise a warning
-    for expected_id in test_case.expected_ids:
-        if result_ids.index(expected_id) > len(test_case.expected_ids):
-            warnings.warn(
-                f"Result {expected_id} was found in position "
-                f"{result_ids.index(expected_id)}, after the "
-                f"{nth(len(test_case.expected_ids))} position, but before the "
-                f"threshold position ({test_case.threshold_position}).",
-                UserWarning,
-            )
-
-    # if the test is strict, check whether the order of the first n result IDs
-    # matches the order of the expected IDs. If they don't match, raise an error
-    if test_case.strict:
-        try:
-            assert (
-                result_ids[: test_case.threshold_position]
-                == test_case.expected_ids
-            )
-        except AssertionError:
-            pytest.fail(
-                f"The order of the expected IDs {test_case.expected_ids} "
-                f"does not match the results: {result_ids}",
-            )

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ..models import RecallTestCase
+from ..executors import do_test_recall
 
 test_cases = [
     RecallTestCase(
@@ -72,18 +73,4 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_recall(test_case: RecallTestCase, client, index, render_query):
-    response = client.search(
-        index=index,
-        query=render_query(test_case.search_terms),
-        size=test_case.threshold_position,
-        _source=False,
-    )
-    result_ids = [result["_id"] for result in response["hits"]["hits"]]
-
-    try:
-        missing_ids = set(test_case.expected_ids) - set(result_ids)
-        assert not missing_ids
-    except AssertionError:
-        pytest.fail(
-            f"{missing_ids} not found in the search results: {result_ids}",
-        )
+    return do_test_recall(test_case, client, index, render_query)

--- a/cli/services/elasticsearch.py
+++ b/cli/services/elasticsearch.py
@@ -9,7 +9,7 @@ from .aws import get_secrets
 common_es_client_config = {
     "timeout": 10,
     "retry_on_timeout": True,
-    "max_retries": 5
+    "max_retries": 5,
 }
 
 

--- a/cli/services/elasticsearch.py
+++ b/cli/services/elasticsearch.py
@@ -6,6 +6,13 @@ from elasticsearch import Elasticsearch
 from .aws import get_secrets
 
 
+common_es_client_config = {
+    "timeout": 10,
+    "retry_on_timeout": True,
+    "max_retries": 5
+}
+
+
 def pipeline_client(
     context: typer.Context, pipeline_date: str
 ) -> Elasticsearch:
@@ -24,6 +31,7 @@ def pipeline_client(
     client = Elasticsearch(
         f"{secrets['protocol']}://{secrets['public_host']}:{secrets['port']}",
         basic_auth=(secrets["es_username"], secrets["es_password"]),
+        **common_es_client_config,
     )
     wait_for_client(client)
     return client
@@ -39,6 +47,7 @@ def rank_client(context: typer.Context) -> Elasticsearch:
     client = Elasticsearch(
         cloud_id=secrets["ES_RANK_CLOUD_ID"],
         basic_auth=(secrets["ES_RANK_USER"], secrets["ES_RANK_PASSWORD"]),
+        **common_es_client_config,
     )
     wait_for_client(client)
     return client
@@ -61,6 +70,7 @@ def reporting_client(context: typer.Context) -> Elasticsearch:
             secrets["read_only/es_username"],
             secrets["read_only/es_password"],
         ),
+        **common_es_client_config,
     )
     wait_for_client(reporting_es_client)
     return reporting_es_client


### PR DESCRIPTION
We've seen some errors from rank due to connection timeouts - I suspect this is because we are making many requests for extremely large pages (10k documents).

These changes make sure that the client is resilient to occasional timeouts, and refactor the test execution logic so that we scroll through smaller pages, bail early on failure/success, and make full use of `O(1)` data structures rather than nested high-cardinality iterators.