### PR TITLE
Test improvements found when removing shingles

### DIFF
--- a/cli/commands/index.py
+++ b/cli/commands/index.py
@@ -194,6 +194,10 @@ def get(
 @app.command()
 def replicate(
     context: typer.Context,
+    pipeline_date: str = typer.Option(
+      default=None,
+      help="The pipeline date from which to replicate, uses the production cluster if unspecified"
+    ),
     source_index: str = typer.Option(
         default=None,
         help=(
@@ -212,11 +216,14 @@ def replicate(
 ):
     """Reindex an index from a production cluster to the rank cluster"""
     context.meta["session"] = aws.get_session(context.meta["role_arn"])
-    prod_template = get_pipeline_search_template(
-        production_api_url, content_type=ContentType.works
-    )
+    if not pipeline_date:
+        prod_template = get_pipeline_search_template(
+            production_api_url, content_type=ContentType.works
+        )
+        pipeline_date = prod_template["index_date"]
+
     pipeline_client = elasticsearch.pipeline_client(
-        context=context, pipeline_date=prod_template["index_date"]
+        context=context, pipeline_date=pipeline_date
     )
     rank_client = context.meta["client"]
 
@@ -247,12 +254,6 @@ def replicate(
         ),
         abort=True,
     ):
-        search_templates = get_pipeline_search_template(
-            production_api_url, content_type=ContentType.works
-        )
-        content_type = context.meta.get("content_type", "works")
-        pipeline_date = search_templates[content_type]["index_date"]
-
         secrets = aws.get_secrets(
             session=context.meta["session"],
             secret_prefix=f"elasticsearch/pipeline_storage_{pipeline_date}/",

--- a/cli/commands/index.py
+++ b/cli/commands/index.py
@@ -195,8 +195,8 @@ def get(
 def replicate(
     context: typer.Context,
     pipeline_date: str = typer.Option(
-      default=None,
-      help="The pipeline date from which to replicate, uses the production cluster if unspecified"
+        default=None,
+        help="The pipeline date from which to replicate, uses the production cluster if unspecified",
     ),
     source_index: str = typer.Option(
         default=None,

--- a/cli/commands/search.py
+++ b/cli/commands/search.py
@@ -187,8 +187,8 @@ def main(
     ),
     stable_sort_key: Optional[str] = typer.Option(
         default="query.id",
-        help="A document property that can be used as a stable sort key"
-    )
+        help="A document property that can be used as a stable sort key",
+    ),
 ):
     if context.invoked_subcommand is None:
         context.meta["session"] = aws.get_session(context.meta["role_arn"])
@@ -258,10 +258,7 @@ def main(
         response = context.meta["client"].search(
             index=context.meta["index"],
             query=json.loads(rendered_query),
-            sort=[
-                {"_score": "desc"},
-                {stable_sort_key: "asc"}
-            ],
+            sort=[{"_score": "desc"}, {stable_sort_key: "asc"}],
             size=n,
             source=["display"],
         )

--- a/cli/commands/search.py
+++ b/cli/commands/search.py
@@ -194,7 +194,7 @@ def main(
             search_template = get_pipeline_search_template(
                 api_url=query, content_type=context.meta["content_type"]
             )
-            index = search_template["index"]
+            index = index if index else search_template["index"]
             query = search_template["query"]
         elif query and os.path.isfile(query):
             with open(query) as file_contents:

--- a/cli/commands/search.py
+++ b/cli/commands/search.py
@@ -185,6 +185,10 @@ def main(
         min=1,
         max=100,
     ),
+    stable_sort_key: Optional[str] = typer.Option(
+        default="query.id",
+        help="A document property that can be used as a stable sort key"
+    )
 ):
     if context.invoked_subcommand is None:
         context.meta["session"] = aws.get_session(context.meta["role_arn"])
@@ -254,6 +258,10 @@ def main(
         response = context.meta["client"].search(
             index=context.meta["index"],
             query=json.loads(rendered_query),
+            sort=[
+                {"_score": "desc"},
+                {stable_sort_key: "asc"}
+            ],
             size=n,
             source=["display"],
         )

--- a/cli/commands/test.py
+++ b/cli/commands/test.py
@@ -73,7 +73,7 @@ def main(
             search_template = get_pipeline_search_template(
                 api_url=query, content_type=context.meta["content_type"]
             )
-            index = search_template["index"]
+            index = index if index else search_template["index"]
             query = search_template["query"]
         elif query and os.path.isfile(query):
             with open(query) as file_contents:

--- a/cli/plugin.py
+++ b/cli/plugin.py
@@ -59,6 +59,10 @@ class RankPlugin:
         return self._index
 
     @fixture()
+    def stable_sort_key(self):
+        return "query.id"
+
+    @fixture()
     def render_query(self):
         def _render_query(search_terms: str):
             rendered = chevron.render(

--- a/cli/relevance_tests/executors.py
+++ b/cli/relevance_tests/executors.py
@@ -3,7 +3,7 @@ import pytest
 from .models import RecallTestCase, PrecisionTestCase, OrderTestCase
 
 
-def do_test_recall(test_case: RecallTestCase, client, index, render_query):
+def do_test_recall(test_case: RecallTestCase, client, index, render_query, stable_sort_key):
     expected_ids = set(test_case.expected_ids)
     received_ids = set([])
     results = client.search(
@@ -11,6 +11,10 @@ def do_test_recall(test_case: RecallTestCase, client, index, render_query):
         _source=False,
         size=max(test_case.threshold_position, len(expected_ids) + 1),
         query=render_query(test_case.search_terms),
+        sort=[
+            {"_score": "desc"},
+            {stable_sort_key: "asc"}
+        ],
     )["hits"]["hits"]
     print(len(results))
     for doc in results:
@@ -29,12 +33,16 @@ def do_test_recall(test_case: RecallTestCase, client, index, render_query):
 
 
 def do_test_precision(
-    test_case: PrecisionTestCase, client, index, render_query
+        test_case: PrecisionTestCase, client, index, render_query, stable_sort_key
 ):
     expected_ids = test_case.expected_ids
     response = client.search(
         index=index,
         query=render_query(test_case.search_terms),
+        sort=[
+            {"_score": "desc"},
+            {stable_sort_key: "asc"}
+        ],
         size=len(expected_ids),
         _source=False,
     )
@@ -52,7 +60,7 @@ def do_test_precision(
         )
 
 
-def do_test_order(test_case: OrderTestCase, client, index, render_query):
+def do_test_order(test_case: OrderTestCase, client, index, render_query, stable_sort_key):
     before_ids = set(test_case.before_ids)
     after_ids = set(test_case.after_ids)
     assert not before_ids.intersection(
@@ -64,6 +72,10 @@ def do_test_order(test_case: OrderTestCase, client, index, render_query):
         _source=False,
         size=test_case.threshold_position,
         query=render_query(test_case.search_terms),
+        sort=[
+            {"_score": "desc"},
+            {stable_sort_key: "asc"}
+        ]
     )["hits"]["hits"]
 
     failures = []

--- a/cli/relevance_tests/executors.py
+++ b/cli/relevance_tests/executors.py
@@ -3,7 +3,9 @@ import pytest
 from .models import RecallTestCase, PrecisionTestCase, OrderTestCase
 
 
-def do_test_recall(test_case: RecallTestCase, client, index, render_query, stable_sort_key):
+def do_test_recall(
+    test_case: RecallTestCase, client, index, render_query, stable_sort_key
+):
     expected_ids = set(test_case.expected_ids)
     received_ids = set([])
     results = client.search(
@@ -11,10 +13,7 @@ def do_test_recall(test_case: RecallTestCase, client, index, render_query, stabl
         _source=False,
         size=max(test_case.threshold_position, len(expected_ids) + 1),
         query=render_query(test_case.search_terms),
-        sort=[
-            {"_score": "desc"},
-            {stable_sort_key: "asc"}
-        ],
+        sort=[{"_score": "desc"}, {stable_sort_key: "asc"}],
     )["hits"]["hits"]
     print(len(results))
     for doc in results:
@@ -33,16 +32,13 @@ def do_test_recall(test_case: RecallTestCase, client, index, render_query, stabl
 
 
 def do_test_precision(
-        test_case: PrecisionTestCase, client, index, render_query, stable_sort_key
+    test_case: PrecisionTestCase, client, index, render_query, stable_sort_key
 ):
     expected_ids = test_case.expected_ids
     response = client.search(
         index=index,
         query=render_query(test_case.search_terms),
-        sort=[
-            {"_score": "desc"},
-            {stable_sort_key: "asc"}
-        ],
+        sort=[{"_score": "desc"}, {stable_sort_key: "asc"}],
         size=len(expected_ids),
         _source=False,
     )
@@ -60,7 +56,9 @@ def do_test_precision(
         )
 
 
-def do_test_order(test_case: OrderTestCase, client, index, render_query, stable_sort_key):
+def do_test_order(
+    test_case: OrderTestCase, client, index, render_query, stable_sort_key
+):
     before_ids = set(test_case.before_ids)
     after_ids = set(test_case.after_ids)
     assert not before_ids.intersection(
@@ -72,10 +70,7 @@ def do_test_order(test_case: OrderTestCase, client, index, render_query, stable_
         _source=False,
         size=test_case.threshold_position,
         query=render_query(test_case.search_terms),
-        sort=[
-            {"_score": "desc"},
-            {stable_sort_key: "asc"}
-        ]
+        sort=[{"_score": "desc"}, {stable_sort_key: "asc"}],
     )["hits"]["hits"]
 
     failures = []

--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -30,4 +30,6 @@ test_cases = [
 def test_alternative_spellings(
     test_case: RecallTestCase, client, index, render_query, stable_sort_key
 ):
-    return do_test_recall(test_case, client, index, render_query, stable_sort_key)
+    return do_test_recall(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/images/test_alternative_spellings.py
+++ b/cli/relevance_tests/images/test_alternative_spellings.py
@@ -28,6 +28,6 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_alternative_spellings(
-    test_case: RecallTestCase, client, index, render_query
+    test_case: RecallTestCase, client, index, render_query, stable_sort_key
 ):
-    return do_test_recall(test_case, client, index, render_query)
+    return do_test_recall(test_case, client, index, render_query, stable_sort_key)

--- a/cli/relevance_tests/images/test_precision.py
+++ b/cli/relevance_tests/images/test_precision.py
@@ -28,5 +28,5 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_precision(test_case: PrecisionTestCase, client, index, render_query):
-    return do_test_precision(test_case, client, index, render_query)
+def test_precision(test_case: PrecisionTestCase, client, index, render_query, stable_sort_key):
+    return do_test_precision(test_case, client, index, render_query, stable_sort_key)

--- a/cli/relevance_tests/images/test_precision.py
+++ b/cli/relevance_tests/images/test_precision.py
@@ -28,5 +28,9 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_precision(test_case: PrecisionTestCase, client, index, render_query, stable_sort_key):
-    return do_test_precision(test_case, client, index, render_query, stable_sort_key)
+def test_precision(
+    test_case: PrecisionTestCase, client, index, render_query, stable_sort_key
+):
+    return do_test_precision(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -55,5 +55,9 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_recall(test_case: RecallTestCase, client, index, render_query, stable_sort_key):
-    return do_test_recall(test_case, client, index, render_query, stable_sort_key)
+def test_recall(
+    test_case: RecallTestCase, client, index, render_query, stable_sort_key
+):
+    return do_test_recall(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -55,5 +55,5 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_recall(test_case: RecallTestCase, client, index, render_query):
-    return do_test_recall(test_case, client, index, render_query)
+def test_recall(test_case: RecallTestCase, client, index, render_query, stable_sort_key):
+    return do_test_recall(test_case, client, index, render_query, stable_sort_key)

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -219,4 +219,6 @@ test_cases = [
 def test_alternative_spellings(
     test_case: RecallTestCase, client, index, render_query, stable_sort_key
 ):
-    return do_test_recall(test_case, client, index, render_query, stable_sort_key)
+    return do_test_recall(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -217,6 +217,6 @@ test_cases = [
     "test_case", [test_case.param for test_case in test_cases]
 )
 def test_alternative_spellings(
-    test_case: RecallTestCase, client, index, render_query
+    test_case: RecallTestCase, client, index, render_query, stable_sort_key
 ):
-    return do_test_recall(test_case, client, index, render_query)
+    return do_test_recall(test_case, client, index, render_query, stable_sort_key)

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -51,7 +51,7 @@ test_cases = [
     OrderTestCase(
         search_terms="AIDS",
         description="Capitalised match appears before lower case match",
-        before_ids=["xn5p9d3v", "mr332fhn", "y3vcj449", "jfhq5hrv"],
+        before_ids=["n9xsxzg7", "mr332fhn", "e2w3hc2t", "jfhq5hrv"],
         after_ids=["gvem6rts", "vfwczwr7"],
     ),
     OrderTestCase(
@@ -66,6 +66,7 @@ test_cases = [
         id="aids poster - ordered terms ahead of unordered terms",
         before_ids=["czgtrmfn", "bry8xyza"],
         after_ids=["e8vnd4s7"],
+        known_failure=True
     ),
     OrderTestCase(
         search_terms="x-ray",

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -51,13 +51,13 @@ test_cases = [
     OrderTestCase(
         search_terms="AIDS",
         description="Capitalised match appears before lower case match",
-        before_ids=["zgyerb26", "sa7tsj82", "qsrzv4ma", "htfhcsaw"],
+        before_ids=["xn5p9d3v", "mr332fhn", "y3vcj449", "jfhq5hrv"],
         after_ids=["gvem6rts", "vfwczwr7"],
     ),
     OrderTestCase(
         search_terms="aid",
         description="Matches exact terms before stemmed terms",
-        before_ids=["ns8dqqu3", "p8e5jrbk", "v63vtprn"],
+        before_ids=["ns8dqqu3", "p8e5jrbk", "whvu96xr"],
         after_ids=["ae6cc6d9", "gvdwhbnd", "er9z8sj4"],
     ),
     OrderTestCase(

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -92,5 +92,5 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_order(test_case: OrderTestCase, client, index, render_query):
-    return do_test_order(test_case, client, index, render_query)
+def test_order(test_case: OrderTestCase, client, index, render_query, stable_sort_key):
+    return do_test_order(test_case, client, index, render_query, stable_sort_key)

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -66,7 +66,7 @@ test_cases = [
         id="aids poster - ordered terms ahead of unordered terms",
         before_ids=["czgtrmfn", "bry8xyza"],
         after_ids=["e8vnd4s7"],
-        known_failure=True
+        known_failure=True,
     ),
     OrderTestCase(
         search_terms="x-ray",
@@ -93,5 +93,9 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_order(test_case: OrderTestCase, client, index, render_query, stable_sort_key):
-    return do_test_order(test_case, client, index, render_query, stable_sort_key)
+def test_order(
+    test_case: OrderTestCase, client, index, render_query, stable_sort_key
+):
+    return do_test_order(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -51,7 +51,7 @@ test_cases = [
     OrderTestCase(
         search_terms="AIDS",
         description="Capitalised match appears before lower case match",
-        before_ids=["n9xsxzg7", "mr332fhn", "e2w3hc2t", "jfhq5hrv"],
+        before_ids=["n9xsxzg7", "mr332fhn", "jfhq5hrv"],
         after_ids=["gvem6rts", "vfwczwr7"],
     ),
     OrderTestCase(

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -151,5 +151,9 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_precision(test_case: PrecisionTestCase, client, index, render_query, stable_sort_key):
-    return do_test_precision(test_case, client, index, render_query, stable_sort_key)
+def test_precision(
+    test_case: PrecisionTestCase, client, index, render_query, stable_sort_key
+):
+    return do_test_precision(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -151,5 +151,5 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_precision(test_case: PrecisionTestCase, client, index, render_query):
-    return do_test_precision(test_case, client, index, render_query)
+def test_precision(test_case: PrecisionTestCase, client, index, render_query, stable_sort_key):
+    return do_test_precision(test_case, client, index, render_query, stable_sort_key)

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -71,6 +71,11 @@ test_cases = [
         description="Matches stemmed arabic text",
         known_failure=True,
     ),
+    RecallTestCase(
+        search_terms="Joint War Committee of the British Red Cross Society and the Order of St. John of Jerusalem in England.",
+        expected_ids=["b3b5dvfy"],
+        description="Long phrase queries should work, and not time out",
+    )
 ]
 
 

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -75,12 +75,16 @@ test_cases = [
         search_terms="Joint War Committee of the British Red Cross Society and the Order of St. John of Jerusalem in England.",
         expected_ids=["b3b5dvfy"],
         description="Long phrase queries should work, and not time out",
-    )
+    ),
 ]
 
 
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_recall(test_case: RecallTestCase, client, index, render_query, stable_sort_key):
-    return do_test_recall(test_case, client, index, render_query, stable_sort_key)
+def test_recall(
+    test_case: RecallTestCase, client, index, render_query, stable_sort_key
+):
+    return do_test_recall(
+        test_case, client, index, render_query, stable_sort_key
+    )

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -82,5 +82,5 @@ test_cases = [
 @pytest.mark.parametrize(
     "test_case", [test_case.param for test_case in test_cases]
 )
-def test_recall(test_case: RecallTestCase, client, index, render_query):
-    return do_test_recall(test_case, client, index, render_query)
+def test_recall(test_case: RecallTestCase, client, index, render_query, stable_sort_key):
+    return do_test_recall(test_case, client, index, render_query, stable_sort_key)

--- a/cli/services/elasticsearch.py
+++ b/cli/services/elasticsearch.py
@@ -7,7 +7,7 @@ from .aws import get_secrets
 
 
 common_es_client_config = {
-    "timeout": 10,
+    "timeout": 5,
     "retry_on_timeout": True,
     "max_retries": 5,
 }


### PR DESCRIPTION
This does the following:

- Adds a test for long phrase searches, which currently fail due to latency issues caused by excessive shingling
- Ensures that tests are stable: documents with equal scores are by default returned in index order which is not stable across reindexes. This PR adds a `stable_sort_key` property to the test fixtures, which is currently set to `query.id`. Some IDs in the expected values for `AIDS` changed as a result of this.
- Adds some missing config options for replicating tests.
- Makes a test for term ordering an `expected_failure`. Re-enabling shingling in the English analyzer for titles only (a) didn't fix this test and (b) noticeably increased query latency. I am not convinced that we need the shingles at all and think that we should wait until we have evidence that this is an issue to address it.