### PR TITLE
try to make case-sensitivity test more reliable

### DIFF
--- a/cli/relevance_tests/works/test_order.py
+++ b/cli/relevance_tests/works/test_order.py
@@ -49,10 +49,16 @@ test_cases = [
         after_ids=["ptvgbenh", "sk78b6pr"],
     ),
     OrderTestCase(
-        search_terms="AIDS",
-        description="Capitalised match appears before lower case match",
-        before_ids=["n9xsxzg7", "e2w3hc2t"],
-        after_ids=["gvem6rts", "vfwczwr7"],
+        search_terms="AIDS diagnosis",
+        description="Case sensitive match appears before insensitive match (upper case)",
+        before_ids=["ruajmye9", "k3fr6kkp"],
+        after_ids=["dhpyj367", "x54kgj8b"],
+    ),
+    OrderTestCase(
+        search_terms="aids diagnosis",
+        description="Case sensitive match appears before insensitive match (lower case)",
+        before_ids=["dhpyj367", "x54kgj8b"],
+        after_ids=["ruajmye9", "k3fr6kkp"],
     ),
     OrderTestCase(
         search_terms="aid",


### PR DESCRIPTION
## What does this change?
See: https://github.com/wellcomecollection/rank/issues/103

I have changed the query term `AIDS` to `AIDS diagnosis`, and also added the opposite case query `aids diagnosis`.

We have been suffering from flakiness in the case-sensitivity tests.  I believe that this is because the term used to exercise this feature is too common in the corpus.

The Order tests work by looking for two sets of records.  The records in the "before" set are expected to appear before the records in the "after" set in the first 100 records returned from the query.  If no records from the "after" set are present, that is also fine, as it indicates they are outside of the top 100.

The problem appears to be that there is no guarantee that the records in the "before" set will be in that top 100, I believe this to be because there are so many equally-relevant records that can be returned from the query `AIDS`, that any record that was returned in the top 100 by one index today could be returned at position 150 by another instance of the index tomorrow.  This could be caused by changes to index mapping, a different version of Elasticsearch or even just by the order in which the documents entered the index.

Furthermore, the opposite case scenario was not being exercised, and because of the prevalence of well-catalogued AIDS content (as opposed to aids content), I don't think this was truly exercising case-aware searching.

## How to test

Once deployed, run an API rank test

## How can we measure success?

We don't have to change the ids in this test every time we change the mappings in the pipeline.

## Have we considered potential risks?

There are still 450 results for the quer(y|ies). This means that there is still scope for the same bug to occur.  Ideally, we would use a term that returns 100 or fewer case-matched records.  That would guarantee that the ids we set here would always be returned by in the top 100.

By being a bit tighter, does this really effectively exercise the feature, or have I overfitted a test where it would have been. more appropriate to fix the query?  I am fairly certain that the flakiness needs to be fixed by a query with fewer matches, but is the case-match boost sufficient?  `aids` still returns lots of `AIDS` content before the first `aids` record.
