### PR TITLE
work m9rdjx58 now redirect to zn4u6s2s and does not come up in search…

### DIFF
--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -174,19 +174,19 @@ test_cases = [
         threshold_position=1000,
         search_terms="neuues",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["ker2t6s4", "m9rdjx58", "nu5dyw37"],
+        expected_ids=["ker2t6s4", "zn4u6s2s", "nu5dyw37"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="nevves",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["ker2t6s4", "m9rdjx58", "nu5dyw37"],
+        expected_ids=["ker2t6s4", "zn4u6s2s", "nu5dyw37"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="newes",
         description="w is folded to match uu and vv in the title",
-        expected_ids=["ker2t6s4", "m9rdjx58", "nu5dyw37"],
+        expected_ids=["ker2t6s4", "zn4u6s2s", "nu5dyw37"],
         known_failure=True,
     ),
     RecallTestCase(


### PR DESCRIPTION
… results

## What does this change?

Change one work id in list of expected_ids to test alternative spellings.
`m9rdjx58` now redirects to `zn4u6s2s` and doesn't come up in search results

## How to test
- Go to [https://wellcomecollection.org/works/m9rdjx58]( https://wellcomecollection.org/works/m9rdjx58) and see that you're redirected to https://wellcomecollection.org/works/zn4u6s2s
- Run the rank tests


## How can we measure success?

Rank tests stop failing 

## Have we considered potential risks?

This is in fact the same work
On `works-indexed-2024-05-13/_doc/m9rdjx58`
```
"redirectTarget": {
      "canonicalId": "zn4u6s2s",
      "sourceIdentifier": {
        "identifierType": {
          "id": "ebsco-alt-lookup"
        },
        "ontologyType": "Work",
        "value": "ebs468571e"
      },
      "otherIdentifiers": []
    },
``` 