### PR TITLE
Make the extremely long query test pass consistently

### DIFF
--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -77,7 +77,7 @@ test_cases = [
         description="Moderately long phrase queries should work, and not time out",
     ),
     RecallTestCase(
-        search_terms="Young Arthur 1741 1820 Rural oeconomy or Essays on the practical parts of husbandry Designed to explain several of the most important methods of conducting farms of various kinds including many useful hints to gentlemen farmers relative to the oeconomical management of their business Containing among other enquiries of that proportioned farm which is of all others the most profitable",
+        search_terms=":(Young Arthur 1741 1820 Rural oeconomy or Essays on the practical parts of husbandry Designed to explain several of the most important methods of conducting farms of various kinds including many useful hints to gentlemen farmers relative to the oeconomical management of their business Containing among other enquiries of that proportioned farm which is of all others the most profitable The best method of conducting farms that consist all of grass or all of arable land The means of keeping the most cattle the year round on a given quantity of land The cheapest way of manuring land Considerations on the oeconomical conduct of gentlemen farmers The comparative profit of farming different soils Of experimental agriculture Of the new husbandry Of the management of borders of arable fields Of periodical publications concerning rural oeconomics To which is added The rural Socrates being memoirs of a country philosopher by the author of The farmer s letters Two lines of quotation in Latin",
         expected_ids=["hpnp6nfy"],
         description="Extremely long phrase queries should work, and not time out",
     ),

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -77,7 +77,7 @@ test_cases = [
         description="Moderately long phrase queries should work, and not time out",
     ),
     RecallTestCase(
-        search_terms=":(Young Arthur 1741 1820 Rural oeconomy or Essays on the practical parts of husbandry Designed to explain several of the most important methods of conducting farms of various kinds including many useful hints to gentlemen farmers relative to the oeconomical management of their business Containing among other enquiries of that proportioned farm which is of all others the most profitable The best method of conducting farms that consist all of grass or all of arable land The means of keeping the most cattle the year round on a given quantity of land The cheapest way of manuring land Considerations on the oeconomical conduct of gentlemen farmers The comparative profit of farming different soils Of experimental agriculture Of the new husbandry Of the management of borders of arable fields Of periodical publications concerning rural oeconomics To which is added The rural Socrates being memoirs of a country philosopher by the author of The farmer s letters Two lines of quotation in Latin",
+        search_terms="Young Arthur 1741 1820 Rural oeconomy or Essays on the practical parts of husbandry Designed to explain several of the most important methods of conducting farms of various kinds including many useful hints to gentlemen farmers relative to the oeconomical management of their business Containing among other enquiries of that proportioned farm which is of all others the most profitable",
         expected_ids=["hpnp6nfy"],
         description="Extremely long phrase queries should work, and not time out",
     ),

--- a/cli/services/elasticsearch.py
+++ b/cli/services/elasticsearch.py
@@ -7,9 +7,9 @@ from .aws import get_secrets
 
 
 common_es_client_config = {
-    "timeout": 10,
+    "timeout": 30,
     "retry_on_timeout": True,
-    "max_retries": 5,
+    "max_retries": 3,
 }
 
 


### PR DESCRIPTION
## What does this change?

This ~reduces the length of the query string~ increases the timeout of the tests testing whether extremely long queries timeout. It looks like this has caused rank test failures intermittently since this was merged, perhaps network latency plays a significant role in tests passing in this case?

This change ~reduces the query length~ increases the timout to one that consistently passes when run locally in order to reduce noice in alerting channels, that is still valid compared to a real user request.

## How to test

- [ ] Check this repository out, follow the docs to run the tests, do they pass?

## How can we measure success?

Less noise in alerts, making it easier to identify real issues.

## Have we considered potential risks?

We could be missing a real issue with something that's changed, though it does look like we've seen failures since https://github.com/wellcomecollection/rank/pull/102 was merged.
