### PR TITLE
Fix rank tests: remove ker2t6s4 from tests

### DIFF
--- a/cli/relevance_tests/executors.py
+++ b/cli/relevance_tests/executors.py
@@ -16,7 +16,6 @@ def do_test_recall(
         query=render_query(test_case.search_terms),
         sort=[{"_score": "desc"}, {stable_sort_key: "asc"}],
     )["hits"]["hits"]
-    print(len(results))
     for doc in results:
         doc_id = doc["_id"]
         try:

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -174,19 +174,19 @@ test_cases = [
         threshold_position=1000,
         search_terms="neuues",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["ker2t6s4", "zn4u6s2s", "nu5dyw37"],
+        expected_ids=["zn4u6s2s", "nu5dyw37"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="nevves",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["ker2t6s4", "zn4u6s2s", "nu5dyw37"],
+        expected_ids=["zn4u6s2s", "nu5dyw37"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="newes",
         description="w is folded to match uu and vv in the title",
-        expected_ids=["ker2t6s4", "zn4u6s2s", "nu5dyw37"],
+        expected_ids=["zn4u6s2s", "nu5dyw37"],
         known_failure=True,
     ),
     RecallTestCase(


### PR DESCRIPTION
## What does this change?

This change removes [`ker2t6s4`](https://wellcomecollection.org/works/ker2t6s4) from our alternative spelling tests as this result is heavily impacted by a recent ingestion of works that are concerned with "nevves". Rather than picking a new work for this test i've removed it as the current set of e-resources may be changed again soon and we have other existing test cases for this.

---

<img width="750" alt="Screenshot 2024-06-25 at 17 05 25" src="https://github.com/wellcomecollection/rank/assets/953792/79f0d566-e5ec-4796-8a78-ffcf59420467">

_From [Good nevves and Bad Nevves by S.R.](https://wellcomecollection.org/works/tcj3pjcd)_

---

## How to test

- [ ] Do the tests pass?

## How can we measure success?

Less false positive failures in the alerts channel.

## Have we considered potential risks?

We are removing a test case so there is the potential we'll miss something, but hopefully this is covered by the other work ids in these test.
