### PR TITLE
Fix nevves/newwes/neuues tests

### DIFF
--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -174,19 +174,19 @@ test_cases = [
         threshold_position=1000,
         search_terms="neuues",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["zn4u6s2s", "nu5dyw37","ker2t6s4"],
+        expected_ids=["zn4u6s2s", "nu5dyw37", "ker2t6s4"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="nevves",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["zn4u6s2s", "nu5dyw37","ker2t6s4"],
+        expected_ids=["zn4u6s2s", "nu5dyw37", "ker2t6s4"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="newes",
         description="w is folded to match uu and vv in the title",
-        expected_ids=["zn4u6s2s", "nu5dyw37","ker2t6s4"],
+        expected_ids=["zn4u6s2s", "nu5dyw37", "ker2t6s4"],
         known_failure=True,
     ),
     RecallTestCase(

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -174,19 +174,20 @@ test_cases = [
         threshold_position=1000,
         search_terms="neuues",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["zn4u6s2s", "nu5dyw37"],
+        expected_ids=["zn4u6s2s", "nu5dyw37","ker2t6s4"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="nevves",
         description="uu is folded to match w and vv in the title",
-        expected_ids=["zn4u6s2s", "nu5dyw37"],
+        expected_ids=["zn4u6s2s", "nu5dyw37","ker2t6s4"],
     ),
     RecallTestCase(
         threshold_position=1000,
         search_terms="newes",
         description="w is folded to match uu and vv in the title",
-        expected_ids=["zn4u6s2s", "nu5dyw37"],
+        expected_ids=["zn4u6s2s", "nu5dyw37","ker2t6s4"],
+        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,

--- a/cli/relevance_tests/works/test_alternative_spellings.py
+++ b/cli/relevance_tests/works/test_alternative_spellings.py
@@ -187,7 +187,6 @@ test_cases = [
         search_terms="newes",
         description="w is folded to match uu and vv in the title",
         expected_ids=["zn4u6s2s", "nu5dyw37"],
-        known_failure=True,
     ),
     RecallTestCase(
         threshold_position=1000,


### PR DESCRIPTION
## What does this change?

This change re-adds some of the test cases from https://github.com/wellcomecollection/rank/pull/108, now we have reduced the number of EBSCO works again.

## How to test

- [x] Run the tests, do they pass?

## How can we measure success?

Passing tests, better test coverage (the last PR removed test cases that were actually useful).

## Have we considered potential risks?

This should be low risk as it doesn't change anything user-facing.
