### PR TITLE
Add rank tests for shelfmarks

### DIFF
--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -146,9 +146,14 @@ test_cases = [
         description="Case-insensitive partial titles",
     ),
     PrecisionTestCase(
-        search_terms="EPB/ENCY/1.v1",
-        expected_ids=["htbq7eqm"],
-        description="Exact match on shelfmark",
+        search_terms="EPB/ENCY/9.v1",
+        expected_ids=["ctuhg29m"],
+        description="Exact match on slash separated shelfmark",
+    ),
+    PrecisionTestCase(
+        search_terms="FTY.S.AI",
+        expected_ids=["cb9mq2d2"],
+        description="Exact match on dot separated shelfmark",
     ),
 ]
 

--- a/cli/relevance_tests/works/test_precision.py
+++ b/cli/relevance_tests/works/test_precision.py
@@ -145,6 +145,11 @@ test_cases = [
         expected_ids=["rtdee482"],
         description="Case-insensitive partial titles",
     ),
+    PrecisionTestCase(
+        search_terms="EPB/ENCY/1.v1",
+        expected_ids=["htbq7eqm"],
+        description="Exact match on shelfmark",
+    ),
 ]
 
 

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -101,7 +101,7 @@ test_cases = [
     ),
     RecallTestCase(
         search_terms="FTY.S",
-        expected_ids=["c5ktw2hd","tbknvqjq","xdcn5n25"],
+        expected_ids=["c5ktw2hd", "tbknvqjq", "xdcn5n25"],
         forbidden_ids=[],
         description="A partial dot separated shelfmark search should return results that have a partial matching shelfmark",
     ),

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -87,6 +87,12 @@ test_cases = [
         forbidden_ids=["r2s5nj96"],
         description="Searches should not return irrelevant images of veterinary ailments",
     ),
+    RecallTestCase(
+        search_terms="EPB/ENCY",
+        expected_ids=["htbq7eqm","ctuhg29m","dsfbdtdz","eznj7hg9","thq463sd"],
+        forbidden_ids=[],
+        description="A partial shelfmark search should return results that have a partial matching shelfmark",
+    ),
 ]
 
 

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -97,7 +97,13 @@ test_cases = [
             "thq463sd",
         ],
         forbidden_ids=[],
-        description="A partial shelfmark search should return results that have a partial matching shelfmark",
+        description="A partial slash separated shelfmark search should return results that have a partial matching shelfmark",
+    ),
+    RecallTestCase(
+        search_terms="FTY.S",
+        expected_ids=["c5ktw2hd","tbknvqjq","xdcn5n25"],
+        forbidden_ids=[],
+        description="A partial dot separated shelfmark search should return results that have a partial matching shelfmark",
     ),
 ]
 

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -100,6 +100,24 @@ test_cases = [
         description="A partial slash separated shelfmark search should return results that have a partial matching shelfmark",
     ),
     RecallTestCase(
+        search_terms="EPB/ENCY/6.v3 EPB/ENCY/1.v5",
+        expected_ids=[
+            "htbq7eqm",
+            "xu3t38ue",
+        ],
+        forbidden_ids=[],
+        description="Multiple results can be returned for shelfmarks in the same query",
+    ),
+    RecallTestCase(
+        search_terms="i12613290 3324V",
+        expected_ids=[
+            "xu3t38ue",
+            "sweyu7qz",
+        ],
+        forbidden_ids=[],
+        description="IDs and shelfmarks can be mixed in the same query and return results",
+    ),
+    RecallTestCase(
         search_terms="FTY.S",
         expected_ids=["c5ktw2hd", "tbknvqjq", "xdcn5n25"],
         forbidden_ids=[],

--- a/cli/relevance_tests/works/test_recall.py
+++ b/cli/relevance_tests/works/test_recall.py
@@ -89,7 +89,13 @@ test_cases = [
     ),
     RecallTestCase(
         search_terms="EPB/ENCY",
-        expected_ids=["htbq7eqm","ctuhg29m","dsfbdtdz","eznj7hg9","thq463sd"],
+        expected_ids=[
+            "htbq7eqm",
+            "ctuhg29m",
+            "dsfbdtdz",
+            "eznj7hg9",
+            "thq463sd",
+        ],
         forbidden_ids=[],
         description="A partial shelfmark search should return results that have a partial matching shelfmark",
     ),


### PR DESCRIPTION
## What does this change?

This adds rank tests for precision and recall of works on shelfmark.

See:
- https://github.com/wellcomecollection/catalogue-pipeline/pull/2693
- https://github.com/wellcomecollection/catalogue-api/pull/807

For https://github.com/wellcomecollection/catalogue-api/pull/807

## How to test

- [x] Run the tests against the new pipeline and API running locally, do they pass?
   ```
   poetry run rank test --content-type=works --pipeline-date=2024-08-15 --query=http://localhost:8080
   ```

## How can we measure success?

We ensure that this indexing and search changes do not detrimentally impact existing searches and are protected against regression in future changes.

## Have we considered potential risks?

Adding these tests should mitigate risk as described above.
