### PR TITLE
Tweak image recall test

### DIFF
--- a/cli/relevance_tests/images/test_recall.py
+++ b/cli/relevance_tests/images/test_recall.py
@@ -16,7 +16,7 @@ test_cases = [
         ],
     ),
     RecallTestCase(
-        search_terms="Frederic Cayley Robinson",
+        search_terms="Frederick Cayley Robinson",
         expected_ids=[
             "avvynvp3",
             "b286u5hw",


### PR DESCRIPTION
## What does this change?

Tweak an image recall test following https://github.com/wellcomecollection/catalogue-api/pull/918.

Indexed image documents in the new index use standard concept labels populated from the graph, which don't always match labels in the existing production index. One of the rank tests is testing for a specific spelling of a name (based on LoC data), but the standard concept label (based on Wikidata) uses a different spelling. 

